### PR TITLE
Disable integration tests known to be flakey

### DIFF
--- a/logdevice/test/CMakeLists.txt
+++ b/logdevice/test/CMakeLists.txt
@@ -45,6 +45,9 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
+set_property(DIRECTORY APPEND PROPERTY TEST_INCLUDE_FILES
+  ${LOGDEVICE_TEST_DIR}/flakey_tests.cmake)
+
 target_link_libraries(integration_test
   common
   common_test_util

--- a/logdevice/test/flakey_tests.cmake
+++ b/logdevice/test/flakey_tests.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Integration tests disabled as faulty or flakey; removed from test
+# list to ensure result of CI run gives a clear signal
+set_tests_properties(
+  "DataSizeTest.RestartNode"
+  "IsLogEmptyTest.LogsTrimmedAway"
+  "IsLogEmptyTest.PartialResult"
+  "IsLogEmptyTest.RestartNode"
+  "NodeSetTest.DeferReleasesUntilMetaDataRead"
+  "NodeStatsControllerIntegrationTest/NodeStatsControllerIntegrationTest.RemoveWorstClients/true"
+  "Parametric/ReadPastGlobalLastReleasedTest.RecoveryStuck/(true,false,1-byteobject<01>)"
+  "ReadingIntegrationTest/ReadingIntegrationTest.StatisticsCallback/false"
+  "SequencerIntegrationTest.LogRemovalStressTest"
+  "SequencerIntegrationTest.MetaDataWritePreempted"
+  "SequencerIntegrationTest.SequencerIsolation"
+  PROPERTIES DISABLED TRUE)


### PR DESCRIPTION
When tests can fail even without regression; confidence in the tests is
undermined. While we work to address the intermittent issues with these
tests remove them from the set so that developers get clear signal of
weather or not their proposed changes cause regression.