### PR TITLE
Fix log noise when running ldshell in LogDevice-OSS

### DIFF
--- a/logdevice/clients/python/CMakeLists.txt
+++ b/logdevice/clients/python/CMakeLists.txt
@@ -14,17 +14,11 @@ REMOVE_MATCHES_FROM_LISTS(files hfiles
 )
 
 add_library(logdevice_python SHARED ${hfiles} ${files})
-add_library(logdevice_python_static STATIC ${hfiles} ${files})
 include_directories(${PYTHON_INCLUDE_DIRS})
 
 message(STATUS "Linking Python bindings with ${PYTHON_LIBRARIES}")
 target_link_libraries(logdevice_python
   ldclient
-  ${Boost_LIBRARIES}
-  ${PYTHON_LIBRARIES})
-
-target_link_libraries(logdevice_python_static
-  ldclient_static
   ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES})
 
@@ -34,11 +28,6 @@ target_link_libraries(logdevice_python_static
 # we split our 'logdevice' namespace into multiple .so binaries (e.g. test)
 set_target_properties(logdevice_python PROPERTIES PREFIX "")
 set_target_properties(logdevice_python PROPERTIES OUTPUT_NAME "client")
-
-set_target_properties(logdevice_python_static PROPERTIES PREFIX "")
-set_target_properties(logdevice_python_static PROPERTIES OUTPUT_NAME "client_static")
-set_target_properties(logdevice_python_static
-  PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 message(STATUS "Python library will be installed to ${_python_dist_path}")
 

--- a/logdevice/ops/ldquery/CMakeLists.txt
+++ b/logdevice/ops/ldquery/CMakeLists.txt
@@ -21,8 +21,8 @@ add_dependencies(ldquery common gason_sources admin_command_client)
 target_link_libraries(ldquery
   common
   logdevice_server
-  logdevice_python_static
-  ldclient_static
+  logdevice_python
+  ldclient
   admin_command_client
   gason_static
   ${SQLITE_LIBRARY}


### PR DESCRIPTION
LogDevice Python C libraries built against static versions for LogDevice
client lib. As multiple bindings defined currentLevel debug setting one
shadowed the other. Moving to use dynamic libs means there are only
single instances of state variable.

Test Plan:

ldshell -s --loglevel info -c /dev/shm/tmp/logdevice/IntegrationTestUtils.c299-eef2-3084-c275/logdevice.conf query 'SELECT * FROM nodes;

with various loglevel values, to ensure get the message levels expected.