### PR TITLE
Define custom target to make documentation

### DIFF
--- a/docs/ldquery-header.md
+++ b/docs/ldquery-header.md
@@ -1,6 +1,0 @@
----
-id: LDQuery
-title: LDQuery
-sidebar_label: LDQuery
----
-

--- a/docs/settings-header.md
+++ b/docs/settings-header.md
@@ -1,6 +1,0 @@
----
-id: Settings
-title: Configuration settings
-sidebar_label: Settings
----
-

--- a/logdevice/CMake/build-docs.cmake
+++ b/logdevice/CMake/build-docs.cmake
@@ -1,0 +1,12 @@
+add_custom_target(settings.md
+	COMMAND logdeviced --markdown-settings > settings.md
+	WORKING_DIRECTORY ${LOGDEVICE_DIR}/../docs
+	DEPENDS logdeviced)
+
+add_custom_target(ldquery.md
+	COMMAND markdown-ldquery > ldquery.md
+	WORKING_DIRECTORY ${LOGDEVICE_DIR}/../docs
+	DEPENDS markdown-ldquery)
+
+add_custom_target(docs)
+add_dependencies(docs settings.md ldquery.md)

--- a/logdevice/CMakeLists.txt
+++ b/logdevice/CMakeLists.txt
@@ -27,6 +27,7 @@ include(build-config)
 
 include(build-folly)
 include(build-rocksdb)
+include(build-docs)
 include(logdevice-deps)
 
 # GTest Project

--- a/logdevice/common/settings/SettingsUpdater.cpp
+++ b/logdevice/common/settings/SettingsUpdater.cpp
@@ -106,6 +106,14 @@ std::string SettingsUpdater::markdownDoc(bool include_deprecated) const {
 
   using std::endl;
 
+  // Markdown header
+  doc << "---" << endl;
+  doc << "id: Settings" << endl;
+  doc << "title: Configuration settings" << endl;
+  doc << "sidebar_label: Settings" << endl;
+  doc << "---" << endl;
+  doc << endl;
+
   for (const auto& cat : cats) {
     doc << "## " << cat.first << endl;
     doc << "|   Name    |   Description   |  Default  |   Notes   |" << endl;

--- a/logdevice/ops/ldquery/markdown-ldquery.cpp
+++ b/logdevice/ops/ldquery/markdown-ldquery.cpp
@@ -32,6 +32,13 @@ int main(int argc, char** argv) {
 
   std::sort(tables.begin(), tables.end(), order_by_name);
 
+  cout << "---" << endl;
+  cout << "id: LDQuery" << endl;
+  cout << "title: LDQuery" << endl;
+  cout << "sidebar_label: LDQuery" << endl;
+  cout << "---" << endl;
+  cout << endl;
+
   for (const TableMetadata& tm : tables) {
     cout << "## " << markdown_sanitize(tm.name) << endl;
     cout << markdown_sanitize(tm.description) << endl << endl;


### PR DESCRIPTION
To simplify the process, add the header in logdeviced and ldquery when markdown
is generated. This avoids complicated CMake rules for creating and then
concatenating files.