### PR TITLE
Update Ratelimiter to reload next_allowed_time in each compare_exchan…

### DIFF
--- a/logdevice/common/RateLimiter.h
+++ b/logdevice/common/RateLimiter.h
@@ -165,10 +165,11 @@ class RateLimiterBase {
     const Duration time_cost = std::chrono::duration_cast<Duration>(
         std::chrono::duration<double>(cost / limit_per_second));
 
-    auto next = next_allowed_time.load();
+    Duration next;
     TimePoint new_next;
     Duration res;
     do {
+      next = next_allowed_time.load();
       res = TimePoint(next) - now; // how long to wait
       if (res.count() <= 0) {
         // No waiting needed.


### PR DESCRIPTION
Update Ratelimiter to reload next_allowed_time  in each compare exchange loop iteration.
If 2 thread try to run the compare exchange loop and one succeed in doing the exchange the other loop would keep using the old value of  next_allowed_time when trying to compare so compare would never succeed.

It look like the only reason we exit the loop is that the value of now eventually get larger than the cached version of next_allowed_time.  