### PR TITLE
Fix cmake builds when cmake version < 3.10

### DIFF
--- a/logdevice/CMakeLists.txt
+++ b/logdevice/CMakeLists.txt
@@ -20,7 +20,11 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 project(${PACKAGE_NAME} CXX)
 
 enable_testing()
-include(GoogleTest OPTIONAL RESULT_VARIABLE HAVE_CMAKE_GTEST)
+# gtest_discover_tests was introduced in cmake 3.10
+if(${CMAKE_VERSION} VERSION_EQUAL "3.10" OR ${CMAKE_VERSION} VERSION_GREATER "3.10")
+  include(GoogleTest OPTIONAL RESULT_VARIABLE HAVE_CMAKE_GTEST)
+endif()
+
 include (logdevice-functions)
 
 include(build-config)


### PR DESCRIPTION
Fix for the first part of #31 

Test strategy:
Build with the fix, no longer get the error:
```
CMake Error at common/CMakeLists.txt:56 (gtest_discover_tests):
  Unknown CMake command "gtest_discover_tests".
```