### PR TITLE
Set python version to 3.6 in cmake dependencies

### DIFF
--- a/logdevice/CMake/logdevice-deps.cmake
+++ b/logdevice/CMake/logdevice-deps.cmake
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # Python version can be chosen by specifying e.g.:
-set(LD_PYTHON_VERSION 3.5 CACHE STRING "Python version")
+set(LD_PYTHON_VERSION 3.6 CACHE STRING "Python version")
 find_package(PythonInterp ${LD_PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${LD_PYTHON_VERSION} REQUIRED)
 


### PR DESCRIPTION
This commit bumps the required python version in the cmake configuration to 3.6.

Without the fix, the following error occurs during the setup of `python-nubia`, during the install phase, after the build is complete.
The important error message is at the end of the log, letting us know that `python-nubia` requires 3.6+.
```
Running python-nubia-0.1b2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-b9mniy56/python-nubia-0.1b2/egg-dist-tmp-0ffmd3tq
Traceback (most recent call last):
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 156, in save_modules
    yield saved
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 197, in setup_context
    yield
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 246, in run_setup
    DirectorySandbox(setup_dir).run(runner)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 276, in run
    return func()
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 245, in runner
    _execfile(setup_script, ns)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 47, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-b9mniy56/python-nubia-0.1b2/setup.py", line 11, in <module>
    setup(
AssertionError: python-nubia requires Python 3.6+

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    "Operating System :: OS Independent",
  File "/usr/lib64/python3.5/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib64/python3.5/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python3.5/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.5/site-packages/setuptools/command/install.py", line 67, in run
    self.do_egg_install()
  File "/usr/lib/python3.5/site-packages/setuptools/command/install.py", line 117, in do_egg_install
    cmd.run()
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 408, in run
    self.easy_install(spec, not self.no_deps)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 644, in easy_install
    return self.install_item(None, spec, tmpdir, deps, True)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 695, in install_item
    self.process_distribution(spec, dist, deps)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 740, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 826, in resolve
    dist = best[req.key] = env.best_match(req, ws, installer)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1098, in best_match
    return self.obtain(req, installer)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1110, in obtain
    return installer(requirement)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 663, in easy_install
    return self.install_item(spec, dist.location, tmpdir, deps)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 693, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 740, in process_distribution
    [requirement], self.local_index, self.easy_install
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 826, in resolve
    dist = best[req.key] = env.best_match(req, ws, installer)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1098, in best_match
    return self.obtain(req, installer)
  File "/usr/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1110, in obtain
    return installer(requirement)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 663, in easy_install
    return self.install_item(spec, dist.location, tmpdir, deps)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 693, in install_item
    dists = self.install_eggs(spec, download, tmpdir)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 874, in install_eggs
    return self.build_and_install(setup_script, setup_base)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 1113, in build_and_install
    self.run_setup(setup_script, setup_base, args)
  File "/usr/lib/python3.5/site-packages/setuptools/command/easy_install.py", line 1099, in run_setup
    run_setup(setup_script, args)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 249, in run_setup
    raise
  File "/usr/lib64/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 197, in setup_context
    yield
  File "/usr/lib64/python3.5/contextlib.py", line 77, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 168, in save_modules
    saved_exc.resume()
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 143, in resume
    six.reraise(type, exc, self._tb)
  File "/usr/lib/python3.5/site-packages/pkg_resources/_vendor/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 156, in save_modules
    yield saved
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 197, in setup_context
    yield
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 246, in run_setup
    DirectorySandbox(setup_dir).run(runner)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 276, in run
    return func()
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 245, in runner
    _execfile(setup_script, ns)
  File "/usr/lib/python3.5/site-packages/setuptools/sandbox.py", line 47, in _execfile
    exec(code, globals, locals)
  File "/tmp/easy_install-b9mniy56/python-nubia-0.1b2/setup.py", line 11, in <module>
    setup(
AssertionError: python-nubia requires Python 3.6+
```


With the fix, the following error is given during cmake configuration time (therefore much earlier in the build process):
```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find PythonInterp: Found unsuitable version "3.5.4", but required
  is at least "3.6" (found /usr/bin/python3)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:375 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindPythonInterp.cmake:152 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMake/logdevice-deps.cmake:9 (find_package)
  CMakeLists.txt:35 (include)


-- Configuring incomplete, errors occurred!
See also "/build/CMakeFiles/CMakeOutput.log".
```

### Test plan:
One can use the current fedora docker containers to try this, as they come with python 3.5. Change `_boost_py_component` to `python3` to get it to find the required boost packages to allow the build to build till the install phase.

When building without the fix, the first error will occur in the install phase.
When building with the fix, the second error will occur in the cmake configuration phase.
