### PR TITLE
Test for automating documenation update from CircleCI Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update
-      - run: apt-get install -y ca-certificates xsltproc $(cat logdevice/build_tools/ubuntu.deps)
+      - run: apt-get install -y ca-certificates doxygen xsltproc $(cat logdevice/build_tools/ubuntu.deps)
       - run: git reset --hard HEAD
       - run: git submodule sync
       - run: git submodule update --init
@@ -26,6 +26,19 @@ jobs:
             cd _build
             cmake ../logdevice/
             make -j 8
+      - run:
+          name: Generate Documentation
+          working_directory: _build
+          command: |
+            make -j 8 docs
+      - run:
+          name: Ensure docs not modified by build
+          command: git diff -s --exit-code -- docs
+      - persist_to_workspace:
+          root: .
+          paths:
+            - website
+            - docs
       - run:
           name: Unit Tests
           working_directory: _build
@@ -50,8 +63,11 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Deploy LogDevice website
+          working_directory: /tmp/workspace
           command: |
             # Configure Docusaurus Bot
             git config --global user.email "docusaurus-bot@users.noreply.github.com"
@@ -68,3 +84,5 @@ workflows:
           filters: *filter-ignore-gh-pages
       - deploy-website:
           filters: *filter-only-master
+          requires:
+            - build


### PR DESCRIPTION
Update Doxygen documentation as part of the CirleCI Job

* Make the docs target
* Check no updates under docs/ to ensure they are kept in-sync
* Chain the output to the input of the website updater

Test plan:

Checked CI jobs ran in sequence, and theat when docs not updated it is
detected and not when they are in-sync
