### PR TITLE
Delay generation and testing of docs on CircleCI (Fix #50)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,18 @@ jobs:
             cmake ../logdevice/
             make -j 8
       - run:
+          name: Unit Tests
+          working_directory: _build
+          command: |
+            mkdir -p ../gtest_results/unit_tests
+            make ARGS="-j 8 --output-on-failure --no-compress-output -T Test" test
+      - run:
+          name: Collect results
+          working_directory: _build
+          command: |
+            xsltproc ../.circleci/conv.xsl Testing/*/Test.xml > ../gtest_results/unit_tests/results.xml
+          when: always
+      - run:
           name: Generate Documentation
           working_directory: _build
           command: |
@@ -39,18 +51,6 @@ jobs:
           paths:
             - website
             - docs
-      - run:
-          name: Unit Tests
-          working_directory: _build
-          command: |
-            mkdir -p ../gtest_results/unit_tests
-            make ARGS="-j 8 --output-on-failure --no-compress-output -T Test" test
-      - run:
-          name: Collect results
-          working_directory: _build
-          command: |
-            xsltproc ../.circleci/conv.xsl Testing/*/Test.xml > ../gtest_results/unit_tests/results.xml
-          when: always
       - store_artifacts:
           path: gtest_results
           when: always


### PR DESCRIPTION
By delaying the generation and testing of documentation on CircleCI until later in the job, it will not interrupt other tasks, such as unit tests.

Fixes #50 