### PR TITLE
Include ldshell in installed debian package

### DIFF
--- a/logdevice/debian/rules
+++ b/logdevice/debian/rules
@@ -1,9 +1,21 @@
 #!/usr/bin/make -f
 %:
-	dh $@ --parallel
+	dh $@ --with python-virtualenv --use-system-packages --parallel
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DNO_PYTHON=TRUE
 
+# Run Cmake steps, need to do these manually, because dh_virtualenv overrides them
+logdevice_cmake:
+	dh_auto_build
+	dh_auto_install
+	dh_link /opt/venvs/logdevice/bin/ldshell /usr/bin/ldshell
+	dh_link /usr/lib/python3.6/dist-packages/logdevice /opt/venvs/logdevice/lib/python3.6/logdevice
+
+override_dh_virtualenv: logdevice_cmake
+	dh_virtualenv --python python3 --sourcedirectory=ops --pip-tool=pip3
+
 override_dh_auto_test:
 	# Unit tests surpressed, for time-being
+
+.PHONY: logdevice_cmake


### PR DESCRIPTION
ldshell requires python-nubia, to both avoid the need for creating an
additional debian package and to control all components included; we use
dh_virtualenv to create the debian package.

Use of the dh_virtualenv debhelper plugin disables a seletion of
debhelper steps, preventing the cmake build from running. To work
successfully within a single source package we call those rules
manually.

To allow ldshell from the virtual environment to "see" logdevice
extensions, a symbolic links are created.

Test Plan:
Installed and started ld-shell to clean Ubuntu Bionic system, using built package served via aptly