### PR TITLE
Configure Ubuntu Docker container shell with utf-8

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -31,6 +31,9 @@ CMD /bin/bash
 # The production image
 FROM ubuntu:bionic
 
+# ldshell _requires_ utf-8
+ENV LANG C.UTF-8
+
 # Copy LogDevice development tools
 COPY --from=builder /build/bin/ld* \
                   /build/bin/logdeviced /usr/local/bin/


### PR DESCRIPTION
utf-8 support is required by ldshell, but not enabled in the default
Ubuntu Docker image.
The fedora:29 docker image was checked and found to support utf-8 by
default, so not change required for that.