### PR TITLE
Deploy from CircleCI to DockerHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - checkout
       - run: apt-get update
-      - run: apt-get install -y ca-certificates docker.io $(cat logdevice/build_tools/ubuntu.deps)
+      - run: apt-get install -y ca-certificates docker.io
       - run: git reset --hard HEAD
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             mkdir -p _build
             cd _build
-            cmake ../logdevice/
+            cmake -DPORTABLE=ON ../logdevice/
             make -j 8
       - run:
           name: Generate Documentation
@@ -87,7 +87,30 @@ jobs:
       - store_test_results:
           path: gtest_results
           when: always
-
+  dockerimage:
+    docker:
+      - image: ubuntu:bionic
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: apt-get update
+      - run: apt-get install -y ca-certificates docker.io $(cat logdevice/build_tools/ubuntu.deps)
+      - run: git reset --hard HEAD
+      - attach_workspace:
+          at: .
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Assemble Docker Image
+          command: |
+            docker build -t facebookincubator/logdevice:latest -f docker/Dockerfile.ci .
+      - run:
+          name: Push Image to DockerHub
+          command: |
+            if [ -n "$DOCKER_PWD" ]; then
+              echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
+              docker push facebookincubator/logdevice:latest
+            fi
 workflows:
   version: 2
   build_and_deploy:
@@ -96,6 +119,10 @@ workflows:
           filters: *filter-ignore-gh-pages
       - unittests:
           filters: *filter-ignore-gh-pages
+          requires:
+            - build
+      - dockerimage:
+          filters: *filter-only-master
           requires:
             - build
       - deploy-website:

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,0 +1,42 @@
+# The production image
+FROM ubuntu:bionic
+
+# ldshell _requires_ utf-8
+ENV LANG C.UTF-8
+
+# Copy LogDevice development tools
+COPY _build/bin/ld* \
+              _build/bin/logdeviced /usr/local/bin/
+
+# Python tools, ldshell, ldquery and client lib
+COPY _build/lib/liblogdevice.so /usr/local/lib/
+COPY _build/lib/client.so \
+    /usr/local/lib/python3.6/dist-packages/logdevice/client.so
+COPY _build/lib/ext.so \
+    /usr/local/lib/python3.6/dist-packages/logdevice/ldquery/internal/ext.so
+COPY _build/lib/admin_command_client.so \
+    /usr/local/lib/python3.6/dist-packages/logdevice/ops/admin_command_client.so
+COPY logdevice/ops/ldquery/py/lib.py \
+    /usr/local/lib/python3.6/dist-packages/logdevice/ldquery/
+COPY logdevice/ops/ldquery/py/__init__.py \
+    /usr/local/lib/python3.6/dist-packages/logdevice/ldquery/
+
+# Install runtime dependencies for ld-dev-cluster, ldshell friends.
+# To install the ldshell wheel we also need python3 build tools, as
+# we depend on python-Levenshtein for which a many-linux binary wheel is not
+# available; these are removed following install to keep docker image size low.
+
+COPY logdevice/build_tools/ubuntu_runtime.deps /tmp/logdevice_runtime.deps
+COPY logdevice/ops /tmp/logdevice/ops
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends $(cat /tmp/logdevice_runtime.deps) \
+        gcc python3-setuptools python3-dev && \
+    python3 -m pip install --user --upgrade setuptools wheel && \
+    (cd /tmp/logdevice/ops && python3 setup.py install) && \
+    apt-get remove -y --auto-remove gcc python3-setuptools python3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4440 4441 4443 5440
+
+CMD /usr/local/bin/ld-dev-cluster

--- a/logdevice/CMake/build-rocksdb.cmake
+++ b/logdevice/CMake/build-rocksdb.cmake
@@ -22,7 +22,7 @@ include(ExternalProject)
 ExternalProject_Add(rocksdb
     SOURCE_DIR "${ROCKSDB_ROOT_DIR}"
     DOWNLOAD_COMMAND ""
-    CMAKE_ARGS -DUSE_RTTI=1
+    CMAKE_ARGS -DUSE_RTTI=1 -DPORTABLE=${PORTABLE}
     INSTALL_COMMAND ""
     )
 

--- a/logdevice/CMakeLists.txt
+++ b/logdevice/CMakeLists.txt
@@ -20,6 +20,8 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 project(${PACKAGE_NAME} CXX)
 
+option(PORTABLE "build a portable binary" OFF)
+
 enable_testing()
 # gtest_discover_tests was introduced in cmake 3.10
 if(${CMAKE_VERSION} VERSION_EQUAL "3.10" OR ${CMAKE_VERSION} VERSION_GREATER "3.10")


### PR DESCRIPTION
In CircleCI we already compile LogDevice within a Docker image. For
this iteration, of the CI to DockerHub flow, we use a targeted Dockerfile
to pulls together the compiled artefacts into a publishable Docker image;
that users can download and run; following the builder/production image
structure implemented in Docker.ubuntu.

During testing, "Illegal Instruction" crashes were observed in using the
resulting container; to resolve this we apply the PORTABLE CMake option.
See https://forums.docker.com/t/getting-illegal-instruction-when-i-run-my-program-inside-container/43919

While in the future, it is planned to only create new Dockerimages on
successful builds, this limit is omitted from the current diff pending
resolution of the current failures.