### PR TITLE
Allow LogDevice to build without Submodules

### DIFF
--- a/build/fbcode_builder/specs/rocksdb.py
+++ b/build/fbcode_builder/specs/rocksdb.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates.
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+def fbcode_builder_spec(builder):
+    builder.add_option("rocksdb/_build:cmake_defines", {
+        "USE_RTTI": "1",
+        "PORTABLE": "ON",
+    })
+    return {
+        "steps": [
+            builder.fb_github_cmake_install("rocksdb/_build"),
+        ],
+    }

--- a/build/fbcode_builder_config.py
+++ b/build/fbcode_builder_config.py
@@ -8,6 +8,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import specs.fizz as fizz
+import specs.folly as folly
+import specs.rocksdb as rocksdb
+import specs.wangle as wangle
 import specs.zstd as zstd
 from shell_quoting import ShellQuoted
 
@@ -38,18 +42,24 @@ def fbcode_builder_spec(builder):
     builder.add_option(
         "no1msd/mstch:git_hash", ShellQuoted("$(git describe --abbrev=0 --tags)")
     )
+    builder.add_option(
+        "LogDevice/logdevice/_build:cmake_defines", {"BUILD_SUBMODULES": "OFF"}
+    )
     return {
-        "depends_on": [zstd],
+        "depends_on": [rocksdb, folly, fizz, wangle, zstd],
         "steps": [
             # This isn't a separete spec, since only fbthrift uses mstch.
             builder.github_project_workdir("no1msd/mstch", "build"),
             builder.cmake_install("no1msd/mstch"),
-            builder.fb_github_cmake_install("LogDevice/logdevice/_build"),
+            builder.fb_github_cmake_install("fbthrift/thrift"),
+            builder.fb_github_cmake_install(
+                "LogDevice/logdevice/_build", github_org="facebookincubator"
+            ),
         ],
     }
 
 
 config = {
-    "github_project": "facebookinubator/LogDevice",
+    "github_project": "facebookincubator/LogDevice",
     "fbcode_builder_spec": fbcode_builder_spec,
 }

--- a/logdevice/CMake/build-folly.cmake
+++ b/logdevice/CMake/build-folly.cmake
@@ -28,6 +28,8 @@ set(FOLLY_LIBRARIES
     ${BINARY_DIR}/libfolly.a)
 set(FOLLY_BENCHMARK_LIBRARIES
     ${BINARY_DIR}/folly/libfollybenchmark.a)
+set(FOLLY_TEST_UTIL_LIBRARIES
+    ${BINARY_DIR}/libfolly_test_util.a)
 
 set(FOLLY_INCLUDE_DIR ${SOURCE_DIR})
 message(STATUS "Folly Library: ${FOLLY_LIBRARIES}")

--- a/logdevice/CMakeLists.txt
+++ b/logdevice/CMakeLists.txt
@@ -40,14 +40,49 @@ include (logdevice-functions)
 
 include(build-config)
 
-include(build-folly)
-include(build-fizz)
-include(build-wangle)
-include(build-fbthrift)
+option(BUILD_SUBMODULES "Build using Git submodules, to fulfil dependencies" ON)
+if(${BUILD_SUBMODULES})
+  include(build-rocksdb)
+  include(build-folly)
+  include(build-fizz)
+  include(build-wangle)
+  include(build-fbthrift)
+  include(${LOGDEVICE_DIR}/external/fbthrift/ThriftLibrary.cmake)
+else()
+  find_package(RocksDB CONFIG REQUIRED)
+  set(ROCKSDB_LIBRARIES RocksDB::rocksdb)
+  find_package(folly CONFIG REQUIRED)
+  set(FOLLY_LIBRARIES Folly::folly)
+  set(FOLLY_BENCHMARK_LIBRARIES Folly::follybenchmark)
+  set(FOLLY_TEST_UTIL_LIBRARIES Folly::folly_test_util)
+  find_package(fizz CONFIG REQUIRED)
+  find_package(wangle CONFIG REQUIRED)
+  find_package(FBThrift CONFIG REQUIRED)
+  find_program(THRIFT1 thrift1)
+  find_path(THRIFT_COMPILER_INCLUDE thrift/templates)
+  set(THRIFT_TEMPLATES ${THRIFT_COMPILER_INCLUDE}/thrift/templates)
+  set(FBTHRIFT_LIBRARIES
+    FBThrift::protocol
+    FBThrift::thriftprotocol
+    FBThrift::transport
+    FBThrift::concurrency
+    FBThrift::thriftfrozen2
+    FBThrift::async
+    FBThrift::thrift-core
+    FBThrift::thriftcpp2
+    FBThrift::thrift
+  )
+  include(${THRIFT_COMPILER_INCLUDE}/thrift/ThriftLibrary.cmake)
 
-include(${LOGDEVICE_DIR}/external/fbthrift/ThriftLibrary.cmake)
+  # If we are not building the submodules, replace targets with fake targets so
+  # that later rules know they are already fulfilled.
+  add_custom_target(rocksdb)
+  add_custom_target(folly)
+  add_custom_target(fizz)
+  add_custom_target(wangle)
+  add_custom_target(fbthrift)
+endif()
 
-include(build-rocksdb)
 include(build-docs)
 include(logdevice-deps)
 

--- a/logdevice/common/CMakeLists.txt
+++ b/logdevice/common/CMakeLists.txt
@@ -53,8 +53,6 @@ target_link_libraries(common_test_util
 
 add_dependencies(common_test_util googletest folly rocksdb OpenTracing)
 
-set(test_files ${test_files} ${LOGDEVICE_DIR}/external/folly/folly/test/DeterministicSchedule.cpp)
-set(test_files ${test_files} ${LOGDEVICE_DIR}/external/folly/folly/test/JsonTestUtil.cpp)
 
 add_executable(common_test ${test_hfiles} ${test_files})
 add_dependencies(common_test googletest folly)
@@ -62,6 +60,7 @@ target_link_libraries(common_test
   common
   common_test_util
   ${LOGDEVICE_EXTERNAL_DEPS}
+  ${FOLLY_TEST_UTIL_LIBRARIES}
   ${GMOCK_LIBRARY}
   ${GTEST_LIBRARY}
   ${LIBGFLAGS_LIBRARY})


### PR DESCRIPTION
As a step in the plan to migrate LogDevice to using fbcode_builder as
the primary build method, allow LogDevice to build without submodules.
In place of the self compiled modules, the CMake scripts will look in
the system (or provided prefix locations) and use precompiled modules
there. Users can then use fbcode_builder to ensure those required
modules are built and available.

* Use new 'folly_test_util' library rather than referencing sources
directly