### PR TITLE
Use fbcode_builder for LogDevice CircleCI builds 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,28 +15,13 @@ jobs:
     steps:
       - checkout
       - run: apt-get update
-      - run: apt-get install -y ca-certificates doxygen $(cat logdevice/build_tools/ubuntu.deps)
-      - run: git reset --hard HEAD
-      - run: git submodule sync
-      - run: git submodule update --init
+      - run: apt-get install -y ca-certificates doxygen python2.7 $(cat logdevice/build_tools/ubuntu.deps)
+      - run: update-alternatives --install /usr/bin/python python /usr/bin/python2.7 10
       - run:
           name: Build LogDevice
+          working_directory: build
           command: |
-            mkdir -p _build
-            cd _build
-            cmake -DPORTABLE=ON ../logdevice/
-            make -j 8
-      - run:
-          name: Generate Documentation
-          working_directory: _build
-          command: |
-            make -j 8 docs
-      - persist_to_workspace:
-          root: .
-          paths:
-            - website
-            - docs
-            - _build
+            python fbcode_builder/shell_builder.py | tee build_logdevice.sh | bash -
   deploy-website:
     docker:
       - image: circleci/node:8.12.0  # Use LTS version of Node.js

--- a/logdevice/build_tools/ubuntu.deps
+++ b/logdevice/build_tools/ubuntu.deps
@@ -44,6 +44,5 @@ libboost-context-dev
 libzstd1-dev
 bison
 flex
-libmstch-dev
 libkrb5-dev
 libsodium-dev


### PR DESCRIPTION
To align with how we build other C-based fbcode projects, transition to fbcode_builder-based builds with CircleCI.

This first cut of the diff is not expected to work; rather being used to test the first bits do.