### PR TITLE
AdminAPI dependencies Membership for thriftpy3

### DIFF
--- a/logdevice/CMake/logdevice-functions.cmake
+++ b/logdevice/CMake/logdevice-functions.cmake
@@ -183,6 +183,7 @@ macro(ld_thrift_py3_library file_name services file_path output_path include_pre
       "${file_path}"
       "${output_path}"
       "${include_prefix}"
+      THRIFT_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/.."
     )
 
     # TODO: Why not read the py3_namespace from the thrift source file?

--- a/logdevice/admin/if/CMakeLists.txt
+++ b/logdevice/admin/if/CMakeLists.txt
@@ -43,7 +43,9 @@ foreach(THRIFT_SOURCE
     "${_adminapi_binary_dir}"
     "${_adminapi_if_include_prefix}"
     PY3_NAMESPACE "logdevice/admin"
-    CYTHON_INCLUDES "${CMAKE_BINARY_DIR}/logdevice/admin/if/gen-py3/"
+    CYTHON_INCLUDES
+      "${CMAKE_BINARY_DIR}/logdevice/admin/if/gen-py3/"
+      "${CMAKE_BINARY_DIR}/logdevice/common/membership/gen-py3/"
   )
 
   add_dependencies(${THRIFT_SOURCE}-cpp2-target fbthrift)
@@ -68,6 +70,7 @@ ld_thrift_py3_library(
     "${CMAKE_BINARY_DIR}/logdevice/admin/gen-py3"
     "${CMAKE_BINARY_DIR}/logdevice"
     "${CMAKE_BINARY_DIR}/fbthrift-prefix/src/fbthrift-build/thrift/lib/py3/cybld"
+    "${CMAKE_BINARY_DIR}/logdevice/common/membership/gen-py3/"
 )
 if(thriftpy3)
   set_source_files_properties(
@@ -126,6 +129,7 @@ add_dependencies(maintenance-${_lang}-target
                  nodes-${_lang}-target
                  safety-${_lang}-target)
 add_dependencies(nodes-${_lang}-target
+                 Membership-${_lang}-target
                  common-${_lang}-target)
 add_dependencies(safety-${_lang}-target
                  common-${_lang}-target

--- a/logdevice/common/membership/CMakeLists.txt
+++ b/logdevice/common/membership/CMakeLists.txt
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 include_directories(${CMAKE_BINARY_DIR})
+link_directories("${CMAKE_BINARY_DIR}/staging/usr/local/lib")
 
 set(
   _membership_if_include_prefix
@@ -15,15 +16,13 @@ file(
   MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${_membership_if_include_prefix}
  )
 
-thrift_library(
+ld_thrift_py3_library(
   "Membership"
-  ""
-  "cpp2"
   ""
   "${CMAKE_CURRENT_SOURCE_DIR}"
   "${CMAKE_BINARY_DIR}/${_membership_if_include_prefix}"
   "${_membership_if_include_prefix}"
-  THRIFT_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/.."
+  PY3_NAMESPACE "logdevice/membership"
  )
 
 add_dependencies(Membership-cpp2-target fbthrift)


### PR DESCRIPTION
Recently the AdminAPI was extended to use the membership API; at the
time these did not cover thriftpy3. This change fills in those gaps and
as a result compilation of logdevice-oss-linux with thriftpy3 ON works
again.

Test plan:
Build