### PR TITLE
fbcode_builder support for using Python virtualenv

### DIFF
--- a/build/fbcode_builder/docker_builder.py
+++ b/build/fbcode_builder/docker_builder.py
@@ -23,7 +23,7 @@ import tempfile
 
 from fbcode_builder import FBCodeBuilder
 from shell_quoting import (
-    raw_shell, shell_comment, shell_join, ShellQuoted
+    raw_shell, shell_comment, shell_join, ShellQuoted, path_join
 )
 from utils import recursively_flatten_list, run_command
 
@@ -47,7 +47,19 @@ class DockerFBCodeBuilder(FBCodeBuilder):
             ShellQuoted('FROM {}'.format(self.option('os_image'))),
             # /bin/sh syntax is a pain
             ShellQuoted('SHELL ["/bin/bash", "-c"]'),
-        ] + self.install_debian_deps() + [self._change_user()])
+        ] + self.install_debian_deps() + [self._change_user()] +
+            [self.workdir(self.option('prefix')),
+             self.create_python_venv(),
+             self.python_venv()])
+
+    def python_venv(self):
+        # To both avoid calling venv activate on each RUN command AND to ensure
+        # it is present when the resulting container is run add to PATH
+        actions = []
+        if self.option("PYTHON_VENV", "OFF") == "ON":
+            actions = ShellQuoted('ENV PATH={p}:$PATH').format(
+            p=path_join(self.option('prefix'), "venv", "bin"))
+        return(actions)
 
     def step(self, name, actions):
         assert '\n' not in name, 'Name {0} would span > 1 line'.format(name)

--- a/build/fbcode_builder/facebook_legocastle_builder.py
+++ b/build/fbcode_builder/facebook_legocastle_builder.py
@@ -61,6 +61,7 @@ class LegocastleFBCodeBuilder(FBCodeBuilder):
 
     def setup(self):
         return self.step('Setup', [
+            self.create_python_venv()] + [
             self.run(ShellQuoted("""
 case "$OSTYPE" in
   darwin*)
@@ -109,7 +110,12 @@ esac
                 )
             elif isinstance(action, LegocastleStep):
                 pre_actions = [
-                    ShellQuoted('set -ex'),
+                    ShellQuoted('set -ex')
+                ]
+                if action.name != 'Setup' and \
+                        self.option("PYTHON_VENV", "OFF") == "ON":
+                    pre_actions.append(self.python_venv())
+                pre_actions.append(
                     ShellQuoted("""
 case "$OSTYPE" in
   darwin*)
@@ -131,8 +137,8 @@ case "$OSTYPE" in
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
   ;;
 esac
-"""),
-                ]
+""")
+                )
                 if next_workdir is not None:
                     pre_actions.append(self.workdir(next_workdir))
 

--- a/build/fbcode_builder/fbcode_builder.py
+++ b/build/fbcode_builder/fbcode_builder.py
@@ -210,6 +210,7 @@ class FBCodeBuilder(object):
             'sudo',
             'unzip',
             'wget',
+            'python3-venv',
         ]
 
     #
@@ -245,6 +246,20 @@ class FBCodeBuilder(object):
         actions.extend(self.debian_ccache_setup_steps())
 
         return self.step('Install packages for Debian-based OS', actions)
+
+    def create_python_venv(self):
+        action = []
+        if self.option("PYTHON_VENV", "OFF") == "ON":
+            action = ShellQuoted("python3 -m venv {p}").format(
+                p=path_join(self.option('prefix'), "venv"))
+        return(action)
+
+    def python_venv(self):
+        action = []
+        if self.option("PYTHON_VENV", "OFF") == "ON":
+            action = ShellQuoted("source {p}").format(
+                p=path_join(self.option('prefix'), "venv", "bin", "activate"))
+        return(action)
 
     def debian_ccache_setup_steps(self):
         return []  # It's ok to ship a renderer without ccache support.

--- a/build/fbcode_builder/shell_builder.py
+++ b/build/fbcode_builder/shell_builder.py
@@ -51,7 +51,7 @@ class ShellFBCodeBuilder(FBCodeBuilder):
     def setup(self):
         steps = [
             ShellQuoted('set -exo pipefail'),
-        ]
+        ] + [self.create_python_venv(), self.python_venv()]
         if self.has_option('ccache_dir'):
             ccache_dir = self.option('ccache_dir')
             steps += [

--- a/build/fbcode_builder_config.py
+++ b/build/fbcode_builder_config.py
@@ -42,6 +42,7 @@ def fbcode_builder_spec(builder):
     builder.add_option(
         "no1msd/mstch:git_hash", ShellQuoted("$(git describe --abbrev=0 --tags)")
     )
+    builder.add_option("PYTHON_VENV", "ON")
     builder.add_option(
         "LogDevice/logdevice/_build:cmake_defines", {"BUILD_SUBMODULES": "OFF"}
     )


### PR DESCRIPTION
Needs to be enabled by option PYTHON_VENV in the config.

Test Plan:
   Docker, Lego and Shell builders tested