### PR TITLE
pinning fmt/rocksdb and fix integration tests initialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run: apt-get install -y ca-certificates doxygen $(cat logdevice/build_tools/ubuntu.deps)
       - run: git reset --hard HEAD
       - run: git submodule sync
-      - run: git submodule update --init
+      - run: git submodule update --init --recursive --remote
       - run:
           name: Build LogDevice
           command: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "logdevice/external/rocksdb"]
 	path = logdevice/external/rocksdb
 	url = https://github.com/facebook/rocksdb/
-	branch = 5.18.fb
+	branch = 6.1.fb
 [submodule "logdevice/external/folly"]
 	path = logdevice/external/folly
 	url = https://github.com/facebook/folly/

--- a/logdevice/CMake/build-fmt.cmake
+++ b/logdevice/CMake/build-fmt.cmake
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 ExternalProject_Add(fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-    GIT_TAG master
+    GIT_TAG 5.3.0
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/external/fmt"
     CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=True

--- a/logdevice/test/CMakeLists.txt
+++ b/logdevice/test/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(test_util
   ${GTEST_LIBRARY}
   ${LOGDEVICE_EXTERNAL_DEPS})
 
-add_executable(integration_test ${hfiles} ${files})
+add_executable(integration_test phony_main.cpp ${hfiles} ${files})
 
 enable_testing()
 if (HAVE_CMAKE_GTEST)

--- a/logdevice/test/phony_main.cpp
+++ b/logdevice/test/phony_main.cpp
@@ -5,4 +5,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
-int main() {}
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <folly/init/Init.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Rocksdb was correctly pinned to 5.18, we need to go up to 6.1
- fbthrift needs older fmt, pinning that similar to how fbcode_builder does it.
- Fixes integration tests folly::init initialisation