### PR TITLE
Building OSS logdevice with c++17

### DIFF
--- a/logdevice/CMake/build-config.cmake
+++ b/logdevice/CMake/build-config.cmake
@@ -4,8 +4,9 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fno-new-ttp-matching")
 set(LOGDEVICE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(LOGDEVICE_ADMIN_DIR "${LOGDEVICE_DIR}/admin")
 set(LOGDEVICE_CLIENT_HEADER_DIR "${LOGDEVICE_DIR}/include")


### PR DESCRIPTION
Boost ICL library fails to compile on c++17 (https://bugzilla.redhat.com/show_bug.cgi?id=1485641). According to the comments on the bug, there's a new feature in c++17 that's preventing it from compiling and it's controlled by the switch `-fnew-ttp-matching`, so in this diff, i'm disabling it as well.