### PR TITLE
Introduce connection factory to Sender.cpp

### DIFF
--- a/logdevice/common/ResourceBudget.h
+++ b/logdevice/common/ResourceBudget.h
@@ -26,8 +26,10 @@ class ResourceBudget {
   explicit ResourceBudget(uint64_t limit) : limit_(limit) {}
 
   // Class responsible for releasing an acquired resource in the RAII fashion.
-  class Token : public boost::noncopyable {
+  class Token {
    public:
+    Token(const Token&) = delete;
+    Token& operator=(const Token&) = delete;
     Token() : budget_(nullptr), count_(0) {}
     Token(Token&& rhs) noexcept : budget_(rhs.budget_), count_(rhs.count_) {
       rhs.budget_ = nullptr;

--- a/logdevice/common/network/ConnectionFactory.h
+++ b/logdevice/common/network/ConnectionFactory.h
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <memory>
+
+#include "logdevice/common/ClientID.h"
+#include "logdevice/common/Connection.h"
+#include "logdevice/common/FlowGroup.h"
+#include "logdevice/common/NodeID.h"
+#include "logdevice/common/ResourceBudget.h"
+#include "logdevice/common/Sockaddr.h"
+#include "logdevice/common/Socket.h"
+#include "logdevice/common/SocketTypes.h"
+
+namespace facebook { namespace logdevice {
+
+struct Settings;
+
+/**
+ * This interface provides a way to create connections for Sender.
+ * Implementations are responsible for management of connections.
+ */
+
+class IConnectionFactory {
+ public:
+  virtual std::unique_ptr<Connection>
+  createConnection(NodeID node_id,
+                   SocketType type,
+                   ConnectionType connection_type,
+                   FlowGroup& flow_group) const = 0;
+
+  virtual std::unique_ptr<Connection>
+  createConnection(int fd,
+                   ClientID client_name,
+                   const Sockaddr& client_address,
+                   ResourceBudget::Token connection_token,
+                   SocketType type,
+                   ConnectionType conntype,
+                   FlowGroup& flow_group) const = 0;
+
+  virtual ~IConnectionFactory() = default;
+
+  virtual void onSettingsUpdated(const Settings& settings) {}
+};
+
+class ConnectionFactory : public IConnectionFactory {
+ public:
+  explicit ConnectionFactory(const Settings& settings) {}
+
+  std::unique_ptr<Connection>
+  createConnection(NodeID node_id,
+                   SocketType type,
+                   ConnectionType connection_type,
+                   FlowGroup& flow_group) const override {
+    return std::make_unique<Connection>(
+        node_id, type, connection_type, flow_group);
+  }
+
+  std::unique_ptr<Connection>
+  createConnection(int fd,
+                   ClientID client_name,
+                   const Sockaddr& client_address,
+                   ResourceBudget::Token connection_token,
+                   SocketType type,
+                   ConnectionType connection_type,
+                   FlowGroup& flow_group) const override {
+    return std::make_unique<Connection>(fd,
+                                        client_name,
+                                        client_address,
+                                        std::move(connection_token),
+                                        type,
+                                        connection_type,
+                                        flow_group);
+  }
+};
+
+}} // namespace facebook::logdevice

--- a/logdevice/common/network/test/ConnectionFactoryTest.cpp
+++ b/logdevice/common/network/test/ConnectionFactoryTest.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "logdevice/common/network/ConnectionFactory.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "logdevice/common/test/MockSettings.h"
+
+namespace facebook { namespace logdevice {
+
+using namespace testing;
+
+TEST(ConnectionFactoryTest, Create) {
+  MockSettings settings;
+  ConnectionFactory factory(settings);
+}
+
+}} // namespace facebook::logdevice

--- a/logdevice/common/test/MockConnectionFactory.h
+++ b/logdevice/common/test/MockConnectionFactory.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "logdevice/common/ClientID.h"
+#include "logdevice/common/FlowGroup.h"
+#include "logdevice/common/NodeID.h"
+#include "logdevice/common/ResourceBudget.h"
+#include "logdevice/common/Sockaddr.h"
+#include "logdevice/common/SocketTypes.h"
+#include "logdevice/common/network/ConnectionFactory.h"
+
+namespace facebook { namespace logdevice {
+
+struct MockConnectionFactory : public IConnectionFactory {
+  MOCK_CONST_METHOD4(createConnection,
+                     std::unique_ptr<Connection>(NodeID node_id,
+                                                 SocketType type,
+                                                 ConnectionType connection_type,
+                                                 FlowGroup& flow_group));
+
+  MOCK_CONST_METHOD7(
+      createConnection,
+      std::unique_ptr<Connection>(int fd,
+                                  ClientID client_name,
+                                  const Sockaddr& client_address,
+                                  ResourceBudget::Token connection_token,
+                                  SocketType type,
+                                  ConnectionType connection_type,
+                                  FlowGroup& flow_group));
+};
+}} // namespace facebook::logdevice

--- a/logdevice/common/test/SenderTest.cpp
+++ b/logdevice/common/test/SenderTest.cpp
@@ -16,6 +16,7 @@
 #include "logdevice/common/configuration/Node.h"
 #include "logdevice/common/configuration/ShapingConfig.h"
 #include "logdevice/common/protocol/Message.h"
+#include "logdevice/common/test/MockConnectionFactory.h"
 #include "logdevice/common/test/MockNodeServiceDiscovery.h"
 #include "logdevice/common/test/MockNodesConfiguration.h"
 #include "logdevice/common/test/MockSettings.h"
@@ -49,6 +50,8 @@ TEST(SenderTest, StartStop) {
   loc.fromDomainString("ash.2.08.k.z");
   std::shared_ptr<Settings> settings = std::make_shared<MockSettings>();
 
+  auto connections = std::make_unique<MockConnectionFactory>();
+
   Sender sender(settings,
                 thread_pool.getEventBase()->getLibeventBase(),
                 sc,
@@ -57,7 +60,9 @@ TEST(SenderTest, StartStop) {
                 nodes,
                 node_index_t{0},
                 loc,
+                std::move(connections),
                 nullptr);
+  // TODO: I haven't been able to mock socket right now,
+  // because of very tricky construction.
 }
-
 }} // namespace facebook::logdevice


### PR DESCRIPTION
Summary:
Introduce connection factory to create connections for sender.

This class will be abstracting all code related to managing connections from Sender. Currently Sender works directly with Socket which is not ideal, because Socket should be a low level abstraction. Also, Socket now knows a lot of stuff i.e negotiating, protocol, traffic shaping etc. We should decompose it and make it more lightweight. Connection and connection factory will help us with managing Connections, connections in turn will use new Socket to maintain a valid connection.

Reviewed By: gdrane

Differential Revision: D14671169

