### PR TITLE
Use external rocksdb repo for fbcode_builder instead of master

### DIFF
--- a/build/fbcode_builder_config.py
+++ b/build/fbcode_builder_config.py
@@ -50,7 +50,7 @@ def fbcode_builder_spec(builder):
         "LogDevice/logdevice/_build:cmake_defines", {"BUILD_SUBMODULES": "OFF"}
     )
     return {
-        "depends_on": [zstd, folly, rocksdb, fizz, wangle, sodium, rsocket, fmt],
+        "depends_on": [zstd, folly, fizz, wangle, sodium, rsocket, fmt],
         "steps": [
             # This isn't a separete spec, since only fbthrift uses mstch.
             builder.github_project_workdir("no1msd/mstch", "build"),

--- a/logdevice/CMakeLists.txt
+++ b/logdevice/CMakeLists.txt
@@ -54,8 +54,11 @@ if(${BUILD_SUBMODULES})
   include(${LOGDEVICE_DIR}/external/fbthrift/ThriftLibrary.cmake)
 else()
   message("Building without submodules")
-  find_package(RocksDB CONFIG REQUIRED)
-  set(ROCKSDB_LIBRARIES RocksDB::rocksdb)
+  include(build-rocksdb)
+  # We're using the external rocksdb even though BUILD_SUBMODULES is OFF because
+  # we don't want to be build against rocksdb master in legocastle.
+  # find_package(RocksDB CONFIG REQUIRED)
+  # set(ROCKSDB_LIBRARIES RocksDB::rocksdb)
   find_package(folly CONFIG REQUIRED)
   set(FOLLY_LIBRARIES Folly::folly)
   set(FOLLY_BENCHMARK_LIBRARIES Folly::follybenchmark)
@@ -84,7 +87,6 @@ else()
 
   # If we are not building the submodules, replace targets with fake targets so
   # that later rules know they are already fulfilled.
-  add_custom_target(rocksdb)
   add_custom_target(folly)
   add_custom_target(fizz)
   add_custom_target(wangle)

--- a/logdevice/admin/if/CMakeLists.txt
+++ b/logdevice/admin/if/CMakeLists.txt
@@ -133,7 +133,9 @@ add_dependencies(admin-${_lang}-target
 
 target_link_libraries(admin-${_lang}
   ${_common_libs}
-  ${LOGDEVICE_EXTERNAL_DEPS}
+  ${FBTHRIFT_LIBRARIES}
+  ${GLOG_LIBRARIES}
+  ${LIBGFLAGS_LIBRARY}
 )
 
 add_dependencies(exceptions-${_lang}-target

--- a/logdevice/common/configuration/nodes/CMakeLists.txt
+++ b/logdevice/common/configuration/nodes/CMakeLists.txt
@@ -37,5 +37,7 @@ set_target_properties(NodesConfiguration-cpp2-obj
 target_link_libraries(
   NodesConfiguration-cpp2
   Membership-cpp2
-  ${LOGDEVICE_EXTERNAL_DEPS}
+  ${FBTHRIFT_LIBRARIES}
+  ${GLOG_LIBRARIES}
+  ${LIBGFLAGS_LIBRARY}
 )


### PR DESCRIPTION
Summary: Using rocksdb from fbcode_builder builds rocksdb from master which results in build failures for backward incompatible changes because our code is compiled against fbcode's rocksdb which is usually behind rocksdb's master. This diff uses the rocksdb submodule instead, which means that we will need to keep it in sync.

Reviewed By: AhmedSoliman

Differential Revision: D16163234

