### PR TITLE
[DynamicPluginLoader] Print dlopen errors on failure

### DIFF
--- a/logdevice/common/plugin/DynamicPluginLoader.cpp
+++ b/logdevice/common/plugin/DynamicPluginLoader.cpp
@@ -49,7 +49,7 @@ PluginVector DynamicPluginLoader::getPlugins() {
     void* handle = dlopen(path.c_str(), RTLD_LOCAL | RTLD_NOW);
     if (handle == nullptr) {
       throw std::runtime_error(
-          folly::sformat("Failed to dlopen '{}'", path.string()));
+          folly::sformat("Failed to dlopen '{}': {}", path.string(), dlerror()));
     }
     void* ptr = dlsym(handle, kLogDevicePluginSymbolName);
     if (ptr == nullptr) {


### PR DESCRIPTION
dlopen fails without specifying the failure reason. Let's print the error to help with debugging. Example after the fix:
```
ubuntu@ip-172-31-29-168 ~/LogdeviceWorkspace/Logdevice/_build [dlopen-error] $ LD_LOAD_PLUGINS=/data/LogdeviceWorkspace/logdevice-prometheus/_build/lib/libldprometheus.so ./bin/logdeviced
terminate called after throwing an instance of 'std::runtime_error'
  what():  Failed to dlopen '/data/LogdeviceWorkspace/logdevice-prometheus/_build/lib/libldprometheus.so': /data/LogdeviceWorkspace/logdevice-prometheus/_build/lib/libldprometheus.so: undefined symbol: _ZN8facebook9logdevice3dbg11customLogFnE
Aborted (core dumped)
```