### PR TITLE
Expose the ConfigPermissionChecker and HELLOPrincipalParser as builtin plugins

### DIFF
--- a/logdevice/common/plugin/BuiltinPermissionCheckerFactory.cpp
+++ b/logdevice/common/plugin/BuiltinPermissionCheckerFactory.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "logdevice/common/plugin/BuiltinPermissionCheckerFactory.h"
+
+#include "logdevice/common/ConfigPermissionChecker.h"
+#include "logdevice/common/debug.h"
+
+namespace facebook { namespace logdevice {
+
+std::shared_ptr<PermissionChecker> BuiltinPermissionCheckerFactory::
+operator()(PermissionCheckerType type,
+           const configuration::SecurityConfig& security_cfg) {
+  switch (type) {
+    case PermissionCheckerType::CONFIG:
+      return std::make_shared<ConfigPermissionChecker>(security_cfg);
+    case PermissionCheckerType::PERMISSION_STORE:
+      // It's better to crash than to return nullptr and grant access to
+      // everyone.
+      ld_critical("PERMISSION_STORE type is not supported in the builtin "
+                  "permission checker factory.");
+      ld_check(false);
+      break;
+    case PermissionCheckerType::NONE:
+      return nullptr;
+    case PermissionCheckerType::MAX:
+      ld_check(false);
+      break;
+  }
+  ld_check(false);
+  return nullptr;
+}
+
+}} // namespace facebook::logdevice

--- a/logdevice/common/plugin/BuiltinPermissionCheckerFactory.h
+++ b/logdevice/common/plugin/BuiltinPermissionCheckerFactory.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "logdevice/common/plugin/PermissionCheckerFactory.h"
+#include "logdevice/common/plugin/PluginRegistry.h"
+
+namespace facebook { namespace logdevice {
+
+/**
+ * @file `BuiltinPermissionCheckerFactory` implementation of the
+ * PermissionCheckerFactory interface. It only supports config based permission
+ * checker.
+ */
+class BuiltinPermissionCheckerFactory : public PermissionCheckerFactory {
+ public:
+  // Plugin identifier
+  std::string identifier() const override {
+    return PluginRegistry::kBuiltin().str();
+  }
+
+  // Plugin display name
+  std::string displayName() const override {
+    return "built-in";
+  }
+
+  std::shared_ptr<PermissionChecker>
+  operator()(PermissionCheckerType type,
+             const configuration::SecurityConfig& security_cfg) override;
+};
+
+}} // namespace facebook::logdevice

--- a/logdevice/common/plugin/BuiltinPrincipalParserFactory.cpp
+++ b/logdevice/common/plugin/BuiltinPrincipalParserFactory.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "logdevice/common/plugin/BuiltinPrincipalParserFactory.h"
+
+#include "logdevice/common/HELLOPrincipalParser.h"
+#include "logdevice/common/debug.h"
+
+namespace facebook { namespace logdevice {
+
+std::unique_ptr<PrincipalParser> BuiltinPrincipalParserFactory::
+operator()(AuthenticationType type) {
+  std::unique_ptr<PrincipalParser> principal_parser = nullptr;
+
+  switch (type) {
+    case AuthenticationType::MAX:
+      ld_check(false);
+      break;
+    case AuthenticationType::NONE:
+      break;
+    case AuthenticationType::SELF_IDENTIFICATION:
+      principal_parser.reset(new HELLOPrincipalParser());
+      break;
+    case AuthenticationType::SSL:
+      ld_critical("AuthenticationType::SSL is not supported in builtin "
+                  "PrincipalParser factory.");
+      break;
+  }
+
+  return principal_parser;
+}
+
+}} // namespace facebook::logdevice

--- a/logdevice/common/plugin/BuiltinPrincipalParserFactory.h
+++ b/logdevice/common/plugin/BuiltinPrincipalParserFactory.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "logdevice/common/plugin/PluginRegistry.h"
+#include "logdevice/common/plugin/PrincipalParserFactory.h"
+
+namespace facebook { namespace logdevice {
+
+/**
+ * @file Implementation of PrincipalParserFactory that only supports
+ * HELLOPrincipalParser.
+ */
+
+class BuiltinPrincipalParserFactory : public PrincipalParserFactory {
+ public:
+  // Plugin identifier
+  std::string identifier() const override {
+    return PluginRegistry::kBuiltin().str();
+  }
+
+  // Plugin display name
+  std::string displayName() const override {
+    return "built-in";
+  }
+
+  std::unique_ptr<PrincipalParser> operator()(AuthenticationType type) override;
+};
+
+}} // namespace facebook::logdevice

--- a/logdevice/common/plugin/CommonBuiltinPlugins.h
+++ b/logdevice/common/plugin/CommonBuiltinPlugins.h
@@ -9,6 +9,8 @@
 
 #include "logdevice/common/BuildInfo.h"
 #include "logdevice/common/plugin/BuiltinConfigSourceFactory.h"
+#include "logdevice/common/plugin/BuiltinPermissionCheckerFactory.h"
+#include "logdevice/common/plugin/BuiltinPrincipalParserFactory.h"
 #include "logdevice/common/plugin/BuiltinZookeeperClientFactory.h"
 #include "logdevice/common/plugin/Plugin.h"
 
@@ -23,6 +25,8 @@ PluginVector createAugmentedCommonBuiltinPluginVector() {
   return createPluginVector<BuildInfo,
                             BuiltinZookeeperClientFactory,
                             BuiltinConfigSourceFactory,
+                            BuiltinPermissionCheckerFactory,
+                            BuiltinPrincipalParserFactory,
                             Types...>();
 }
 


### PR DESCRIPTION
Summary:
To save OSS users from writing a whole PermissionCheckerFactory plugin, we can expose the default ConfigPermissionChecker as a builtin plugin for those who are ok with it. For those who have a custom permission store, they will still need to implement there own plugin.
I'm also exposing the HELLOPrincipalParser in the default plugin. Basically with this diff, you can enforce config based permissions with self_identifications as the authentication type.

Differential Revision: D17181157

