### PR TITLE
sync all_read_streams_debug_config to fbcode

### DIFF
--- a/logdevice/common/configuration/if/CMakeLists.txt
+++ b/logdevice/common/configuration/if/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+include_directories(${CMAKE_BINARY_DIR})
+link_directories("${CMAKE_BINARY_DIR}/staging/usr/local/lib")
+
+set(
+  _configuration_if_include_prefix
+  "logdevice/common/configuration/if"
+ )
+
+file(
+  MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${_configuration_if_include_prefix}
+ )
+
+ld_thrift_py3_library(
+  "Membership"
+  ""
+  "json"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_BINARY_DIR}/${_configuration_if_include_prefix}"
+  "${_configuration_if_include_prefix}"
+  PY3_NAMESPACE "logdevice/configuration"
+ )
+
+add_dependencies(Membership-cpp2-target fbthrift)
+
+set_target_properties(
+        Membership-cpp2-obj
+        PROPERTIES POSITION_INDEPENDENT_CODE True
+)
+
+target_link_libraries(
+  Membership-cpp2
+  ${THRIFT_DEPS}
+)

--- a/logdevice/common/configuration/if/all_read_streams_debug_config/config.thrift
+++ b/logdevice/common/configuration/if/all_read_streams_debug_config/config.thrift
@@ -1,0 +1,7 @@
+namespace py3 logdevice.all_read_streams_debug_config
+namespace cpp2 logdevice.all_read_streams_debug_config.config
+
+struct LogdeviceAllReadStreamsDebugConfig {
+  1: set<string> allowed_csids = [];
+  2: optional i64 deadline;
+}


### PR DESCRIPTION
Summary: sync all_read_streams_debug_config to fbcode

Reviewed By: lucaspmelo, spuzirev

Differential Revision: D17132163

