### PR TITLE
Fix a bug in AdminCommandClient when connection fails inline

### DIFF
--- a/logdevice/ops/admin_command_client/AdminCommandClient.cpp
+++ b/logdevice/ops/admin_command_client/AdminCommandClient.cpp
@@ -282,9 +282,9 @@ AdminCommandClient::semifuture_send(
           connections.push_back(std::move(connection));
         }
         connections_size = connections.size();
-        do {
+        while (connections_done < connections_size && !timed_out) {
           event_base.loopOnce();
-        } while (connections_done < connections_size && !timed_out);
+        }
       }
 
       if (timed_out) {


### PR DESCRIPTION
Summary: If the socket connection fails inline (e.g. when the unix socket doesn't exist), we will get stuck in the event_base::loopOnce call until the command timeout kicks in which causes tests to timeout. This diff checks first if there are any connections that are still pending before waiting on the event loop.

Differential Revision: D17600881

