### PR TITLE
fix release build under gcc-7.4 and gcc-8 (Ubuntu 18.4)

### DIFF
--- a/logdevice/lib/ClientImpl.cpp
+++ b/logdevice/lib/ClientImpl.cpp
@@ -2305,6 +2305,19 @@ ClientImpl::prepareRequest(logid_t logid,
   }
   return req;
 }
+
+// Some compilers (e.g., gcc-7.4.0, the default compiler on Ubuntu 18) may inline calls to prepareRequest<Payload>() in
+// ClientImpl::append() below. If that happens, the compiler will not generate code for prepareRequest<Payload>()
+// instantiation. However, lib/shadow/ShadowClient.cpp requires that instantiation. This leads to link errors when
+// linking examples/ and some tests. Adding an explicit instantiation here to fix.
+template std::unique_ptr<AppendRequest> 
+ClientImpl::prepareRequest<Payload>(logid_t logid,
+                        Payload payload,
+                        append_callback_t cb,
+                        AppendAttributes attrs,
+                        worker_id_t target_worker,
+                        std::unique_ptr<std::string> per_request_token);
+
 void ClientImpl::initLogsConfigRandomSeed() {
   logsconfig_api_random_seed_ = folly::Random::rand64();
 }

--- a/logdevice/lib/ClientImpl.cpp
+++ b/logdevice/lib/ClientImpl.cpp
@@ -2306,10 +2306,12 @@ ClientImpl::prepareRequest(logid_t logid,
   return req;
 }
 
-// Some compilers (e.g., gcc-7.4.0, the default compiler on Ubuntu 18) may inline calls to prepareRequest<Payload>() in
-// ClientImpl::append() below. If that happens, the compiler will not generate code for prepareRequest<Payload>()
-// instantiation. However, lib/shadow/ShadowClient.cpp requires that instantiation. This leads to link errors when
-// linking examples/ and some tests. Adding an explicit instantiation here to fix.
+// Some compilers (e.g., gcc-7.4.0, the default compiler on Ubuntu 18) may
+// inline calls to prepareRequest<Payload>() in ClientImpl::append() below. If
+// that happens, the compiler will not generate code for
+// prepareRequest<Payload>() instantiation. However, lib/shadow/ShadowClient.cpp
+// requires that instantiation. This leads to link errors when linking examples/
+// and some tests. Adding an explicit instantiation here to fix.
 template std::unique_ptr<AppendRequest> 
 ClientImpl::prepareRequest<Payload>(logid_t logid,
                         Payload payload,

--- a/logdevice/server/RebuildingWakeupQueue.h
+++ b/logdevice/server/RebuildingWakeupQueue.h
@@ -53,14 +53,14 @@ class RebuildingWakeupQueue {
     RecordTimestamp nextTimestamp;
 
     struct TimestampComparer {
-      bool operator()(const LogState& a, const LogState& b) {
+      bool operator()(const LogState& a, const LogState& b) const {
         return std::tie(a.nextTimestamp, a.logId) <
             std::tie(b.nextTimestamp, b.logId);
       }
     };
 
     struct LogIdComparer {
-      bool operator()(const LogState& a, const LogState& b) {
+      bool operator()(const LogState& a, const LogState& b) const {
         return a.logId < b.logId;
       }
     };


### PR DESCRIPTION
* added an explicit instantiation of ClientImpl::prepareRequest<Payload>() to fix an undefined symbol error while linking client tests and examples under gcc-7.4

* added const declarations that tripped a static_assert in libstdc++ in the OSS build under gcc-8 on Ubuntu 18.4 