### PR TITLE
Reducing parallelism to avoid running out of memory on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             mkdir -p _build
             cd _build
             cmake -DPORTABLE=ON ../logdevice/
-            make -j $(($(nproc)-1))
+            make -j 5
       - run:
           name: Generate Documentation
           working_directory: _build


### PR DESCRIPTION
Going from 7 to 6 because we run out of memory on Circle CI :(