### PR TITLE
Enabling TCP by default in docker ld-dev-cluster run

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -79,4 +79,4 @@ RUN apt-get update && \
 
 EXPOSE 4440 4441 4443 5440 6440
 
-CMD /usr/local/bin/ld-dev-cluster
+CMD /usr/local/bin/ld-dev-cluster --use-tcp


### PR DESCRIPTION
This enables the ld-dev-server by default in the docker container to use TCP instead of unix sockets.