### PR TITLE
Moving checkout to the top

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,9 @@ jobs:
       - image: ubuntu:bionic
     resource_class: xlarge
     steps:
+      - checkout
       - run: apt-get update
       - run: apt-get install -y ca-certificates git docker.io
-      - checkout
       - run: git reset --hard HEAD
       - run: git submodule sync
       - run: git submodule update --init --recursive


### PR DESCRIPTION
This should (in theory) fix the circle CI issue pulling the git submodules on the docker build stage