### PR TITLE
Fix replication checker naming in open source and ensure that tests use it correctly

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -48,7 +48,6 @@ ENV LANG C.UTF-8
 # Copy LogDevice user tools
 COPY --from=builder /build/bin/ld* \
                   /build/bin/logdeviced \
-                  /build/bin/replication_checker \
                   /usr/local/bin/
 
 # Python tools, ldshell, ldquery and libs

--- a/logdevice/replication_checker/CMakeLists.txt
+++ b/logdevice/replication_checker/CMakeLists.txt
@@ -10,9 +10,9 @@ add_library(replication_checker_lib
             "ReplicationCheckerSettings.cpp")
 add_dependencies(replication_checker_lib folly common)
 
-add_executable(replication_checker main.cpp)
+add_executable(ld-replication-checker main.cpp)
 
-target_link_libraries(replication_checker
+target_link_libraries(ld-replication-checker
   replication_checker_lib
   common
   ldclient_static

--- a/logdevice/test/utils/IntegrationTestUtils.cpp
+++ b/logdevice/test/utils/IntegrationTestUtils.cpp
@@ -89,7 +89,7 @@ std::string defaultLogdevicedPath() {
 std::string defaultMarkdownLDQueryPath() {
   return "bin/markdown-ldquery";
 }
-static const char* CHECKER_PATH = "bin/replication_checker_nofb";
+static const char* CHECKER_PATH = "bin/ld-replication-checker";
 #endif
 
 namespace fs = boost::filesystem;


### PR DESCRIPTION
Summary: This should fix the rebuilding failing tests in OSS

Differential Revision: D18851595

