### PR TITLE
decrease circle ci parallelism to 4 in the docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run:
           name: Assemble Docker Image (Ubuntu)
           command: |
-            docker build -t facebookincubator/logdevice:latest --build-arg PARALLEL=5 -f docker/Dockerfile.ubuntu .
+            docker build -t facebookincubator/logdevice:latest --build-arg PARALLEL=4 -f docker/Dockerfile.ubuntu .
       - run:
           name: Push Image to DockerHub
           command: |


### PR DESCRIPTION
Attempt to void running out of memory during the docker image build