### PR TITLE
Fix the circle ci config, and build docker image on tagged commits 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,10 +127,13 @@ workflows:
           filters:
             branches:
               only: master
+    jobs:
+      - dockerimage:
+          filters:
+            branches:
+              only: master
             tags:
               only: /.*/
-    jobs:
-      - dockerimage
   build_and_test:
     jobs:
       - build:
@@ -145,3 +148,9 @@ workflows:
               only: master
           requires:
             - build
+      - dockerimage:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
What is this supposed to do:
- Build nightly from master and publish a docker image
- Immediately build an image from a (tagged) commit