### PR TITLE
Fixing ldshell linking issue

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -60,7 +60,7 @@ COPY --from=builder /build/staging/usr/local/lib/*.so /usr/local/lib/
 # LDShell, LDops, ldquery, etc.
 COPY --from=builder /build/python-out/dist/ldshell-*.whl /tmp/
 # LogDevice client library python bindings
-COPY --from=builder /build/lib/liblogdevice.so /usr/local/lib/
+COPY --from=builder /build/lib/*.so /usr/local/lib/
 
 # Install runtime dependencies for ld-dev-cluster, ldshell friends.
 # To install the ldshell wheel we also need python3 build tools, as

--- a/logdevice/clients/python/CMakeLists.txt
+++ b/logdevice/clients/python/CMakeLists.txt
@@ -3,12 +3,16 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
+add_subdirectory(util)
+
 auto_sources(hfiles "*.h" RECURSE "${LOGDEVICE_PYTHON_CLIENT_DIR}")
 auto_sources(files "*.cpp" RECURSE "${LOGDEVICE_PYTHON_CLIENT_DIR}")
 
 REMOVE_MATCHES_FROM_LISTS(files hfiles
   MATCHES
-    "test/*"
+    "/util/"
+    "/tests/"
     "logdevice_settings.cpp"  # Settings depends on server at the moment >.<
 )
 
@@ -17,6 +21,7 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 
 message(STATUS "Linking Python bindings with ${PYTHON_LIBRARIES}")
 target_link_libraries(logdevice_python
+  logdevice_python_util
   ldclient
   ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}

--- a/logdevice/clients/python/logdevice_client.cpp
+++ b/logdevice/clients/python/logdevice_client.cpp
@@ -13,6 +13,7 @@
 #include <boost/python.hpp>
 #include <folly/container/Array.h>
 
+#include "logdevice/clients/python/logdevice_client.h"
 #include "logdevice/clients/python/logdevice_logsconfig.h"
 #include "logdevice/clients/python/util/util.h"
 #include "logdevice/common/Semaphore.h"

--- a/logdevice/clients/python/logdevice_client.h
+++ b/logdevice/clients/python/logdevice_client.h
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+#include <boost/python.hpp>
+
+// raise a LogDevice error (logdevice::err) as a Python exception
+// throws, and never returns, ever.
+[[noreturn]] void throw_logdevice_exception(
+    boost::python::object extra = boost::python::object());
+
+// helper to wrap a logdevice Reader instance for return to Python, since we
+// need to do some clever things to make it work cleanly.
+namespace facebook { namespace logdevice {
+class Reader;
+}}; // namespace facebook::logdevice
+
+boost::python::object
+    wrap_logdevice_reader(std::unique_ptr<facebook::logdevice::Reader>);
+
+// multiple C++ modules in the single end object requires registration
+void register_logdevice_reader();
+void register_logdevice_record();

--- a/logdevice/clients/python/logdevice_logsconfig.h
+++ b/logdevice/clients/python/logdevice_logsconfig.h
@@ -9,6 +9,7 @@
 
 #include <boost/python.hpp>
 
+#include "logdevice/clients/python/logdevice_client.h"
 #include "logdevice/clients/python/util/util.h"
 #include "logdevice/common/configuration/NodeLocation.h"
 #include "logdevice/include/Client.h"

--- a/logdevice/clients/python/logdevice_reader.cpp
+++ b/logdevice/clients/python/logdevice_reader.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/make_shared.hpp>
 
+#include "logdevice/clients/python/logdevice_client.h"
 #include "logdevice/clients/python/util/util.h"
 #include "logdevice/include/Client.h"
 

--- a/logdevice/clients/python/util/CMakeLists.txt
+++ b/logdevice/clients/python/util/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+auto_sources(hfiles "*.h" RECURSE "${LOGDEVICE_PYTHON_CLIENT_DIR}/util")
+auto_sources(files "*.cpp" RECURSE "${LOGDEVICE_PYTHON_CLIENT_DIR}/util")
+
+message(STATUS "Building ${hfiles} ${files}")
+add_library(logdevice_python_util SHARED ${hfiles} ${files})
+
+include_directories(${PYTHON_INCLUDE_DIRS})
+
+add_dependencies(logdevice_python_util folly)
+
+target_link_libraries(logdevice_python_util
+  ${FOLLY_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${PYTHON_LIBRARIES}
+)
+
+install(TARGETS logdevice_python_util
+  COMPONENT runtime
+  DESTINATION lib
+)

--- a/logdevice/clients/python/util/util.h
+++ b/logdevice/clients/python/util/util.h
@@ -46,11 +46,6 @@ make_boost_shared_ptr_from_std_shared_ptr(std::shared_ptr<T> ptr) {
   return boost::shared_ptr<T>(ptr.get(), [ptr](T*) mutable { ptr.reset(); });
 }
 
-// raise a LogDevice error (logdevice::err) as a Python exception
-// throws, and never returns, ever.
-[[noreturn]] void throw_logdevice_exception(
-    boost::python::object extra = boost::python::object());
-
 // If `coerce` is true, converts numeric and boolean types to string.
 std::string extract_string(const boost::python::object& from,
                            const char* name,
@@ -91,21 +86,9 @@ createExceptionClass(const char* name,
                      const char* doc = nullptr,
                      PyObject* baseClass = PyExc_Exception);
 
-// helper to wrap a logdevice Reader instance for return to Python, since we
-// need to do some clever things to make it work cleanly.
-namespace facebook { namespace logdevice {
-class Reader;
-}}; // namespace facebook::logdevice
-
-boost::python::object
-    wrap_logdevice_reader(std::unique_ptr<facebook::logdevice::Reader>);
 
 template <typename T>
 inline std::vector<T> to_std_vector(const boost::python::object& iterable) {
   return std::vector<T>(boost::python::stl_input_iterator<T>(iterable),
                         boost::python::stl_input_iterator<T>());
 }
-
-// multiple C++ modules in the single end object requires registration
-void register_logdevice_reader();
-void register_logdevice_record();

--- a/logdevice/ops/ldshell/main.py
+++ b/logdevice/ops/ldshell/main.py
@@ -8,6 +8,20 @@
 
 import sys
 
+# This is the mother of all hacks!
+# There is possibly:
+#   a) Compiler bug that makes sending exceptions across the boundary of the
+#   shared library look weird to Python.
+#   b) Boost-Python bug that causes throw_error_already_set() to crash the
+#   python process (SIGABRT).
+#   c) A Python bug (tested on 3.6.9)
+# The effect is that if Client is loaded via our automatic loading, throwing
+# Python exceptions from our C++ bindings will cause the process to crash. This
+# faux import here is added to ensure the module/extension is loaded before any
+# dynamic/automatic loading later.
+# TODO: Consider removing when updating Python/Boost/GCC=>Clang.
+from logdevice.client import Client
+
 from ldshell.autoload import commands
 from ldshell.logdevice_plugin import LogDevicePlugin
 from nubia import Nubia

--- a/logdevice/ops/py_extensions/admin_command_client/CMakeLists.txt
+++ b/logdevice/ops/py_extensions/admin_command_client/CMakeLists.txt
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 add_library(admin_command_client STATIC AdminCommandClient.h AdminCommandClient.cpp)
-add_dependencies(admin_command_client common folly)
+add_dependencies(admin_command_client folly)
 
 target_link_libraries(admin_command_client
-   ${LOGDEVICE_EXTERNAL_DEPS}
+  common
+  ${LOGDEVICE_EXTERNAL_DEPS}
 )
 
 set_target_properties(admin_command_client

--- a/logdevice/ops/py_extensions/admin_command_client/py/CMakeLists.txt
+++ b/logdevice/ops/py_extensions/admin_command_client/py/CMakeLists.txt
@@ -11,6 +11,7 @@ python_add_module(logdevice_admin_command_client_python
 include_directories(${PYTHON_INCLUDE_DIRS})
 
 target_link_libraries(logdevice_admin_command_client_python
+  logdevice_python_util
   admin_command_client
 )
 

--- a/logdevice/ops/py_extensions/nodes_configuration/CMakeLists.txt
+++ b/logdevice/ops/py_extensions/nodes_configuration/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 add_dependencies(logdevice_nodes_configuration_manager_python fbthrift)
 
 target_link_libraries(logdevice_nodes_configuration_manager_python
-  logdevice_python
+  logdevice_python_util
   ldclient
   ${Boost_LIBRARIES}
   ${THRIFT_DEPS}


### PR DESCRIPTION
This fixes issues that started appearing after we added more python extensions (namely the nodes_configuration_manager).
- Split the clients/python/util into its own target (shared library in this case) as this is reused between multiple extensions.
- Fix some of the dependencies in admin_command_client which needs logging (link against common)
- Fix a very weird bug where our python extensions crash the python process if it throws a Python exception in a very weird edge case that only happen after we load the commands dynamically. After spending hours trying to figure out why exactly this is happening, I have resorted into the mother of all hacks (look at it in the PR).