### PR TITLE
Disable CircleCI dockerimage on every commit on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,5 +152,7 @@ workflows:
           requires:
             - build
           filters:
+            branches:
+              ignore: master
             tags:
               only: /.*/


### PR DESCRIPTION
This should stop circle ci from building the image on every commit