### PR TITLE
docs: correct the number of submodules in installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,14 @@ At this time, the only supported platform is Ubuntu 18 LTS "Bionic Beaver". Supp
 git clone --recurse-submodules git://github.com/facebookincubator/LogDevice
 ```
 
-This creates a top-level `LogDevice` directory, with the source code in `LogDevice/logdevice`. There are two git submodules in the tree: `logdevice/external/folly` and `logdevice/external/rocksdb`.
+This creates a top-level `LogDevice` directory, with the source code in `LogDevice/logdevice`. There are six git submodules in the tree:
+```
+logdevice/external/fbthrift
+logdevice/external/fizz
+logdevice/external/folly
+logdevice/external/rocksdb
+logdevice/external/wangle
+```
 
 **Install packages that LogDevice depends on.**
 


### PR DESCRIPTION
PR corrects the number of submodules in the instructions in `docs/installation.md`.

```
$ git config --file .gitmodules --name-only --get-regexp path | wc -l
       5

$ git config --file .gitmodules --name-only --get-regexp path | sort
submodule.logdevice/external/fbthrift.path
submodule.logdevice/external/fizz.path
submodule.logdevice/external/folly.path
submodule.logdevice/external/rocksdb.path
submodule.logdevice/external/wangle.path
```

