### PR TITLE
Remove --use-tcp since this causes problems with ldshell

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -78,4 +78,4 @@ RUN apt-get update && \
 
 EXPOSE 4440 4441 4443 5440 6440
 
-CMD /usr/local/bin/ld-dev-cluster --use-tcp
+CMD /usr/local/bin/ld-dev-cluster


### PR DESCRIPTION
LDQuery currently has port 5440 hard coded for the command port, this makes ldshell's select command useless for ld-dev-cluster use case if --use-tcp. Disabling this unless the user specifies that explicitly until this is resolved.