### PR TITLE
Rename references of storage_weight to storage_capacity in docs

### DIFF
--- a/docs/Write_path.md
+++ b/docs/Write_path.md
@@ -120,10 +120,10 @@ Many clients can write to the same log. Records are written in sequence number o
 
 If you have a heterogeneous set of hardware, you can configure weights for storage and sequencer nodes in the node configuration. The weight values are used to balance APPENDs across sequencer nodes and STOREs across storage nodes.
 
-* `storage_weight` defines the amount of data to be stored compared to other machines. You should assign weights to systems according to their relative disk size.
+* `storage_capacity` defines the amount of data to be stored compared to other machines. You should assign weights to systems according to their relative disk size.
 * `sequencer_weight` is used when determining number of sequencers to be placed on a node. Assign a larger weight to the nodes with the fastest hardware / most memory.
 
-[See how to configure `sequencer_weight` and `storage_weight`.](configuration.md#roles-and-state-roles-sequencer-sequencer_weight-storage-and-storage_weight)
+[See how to configure `sequencer_weight` and `storage_capacity`.](configuration.md#roles-and-state-roles-sequencer-sequencer_weight-storage-and-storage_capacity)
 
 ### Load balancing across logs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,7 +203,7 @@ can be placed on machines with 3 different rack identifiers (but could share sam
 
 Each section can be expressed as a string.
 
-### Roles and state (`roles`, `sequencer`, `sequencer_weight`, `storage` and `storage_weight`)
+### Roles and state (`roles`, `sequencer`, `sequencer_weight`, `storage` and `storage_capacity`)
 A distinction should be made between roles and state:
 - Role: this remains the same during the lifetime of the node.
 - State: could change (for e.g. maintenance operations)

--- a/website/versioned_docs/version-2.46.5/Write_path.md
+++ b/website/versioned_docs/version-2.46.5/Write_path.md
@@ -121,10 +121,10 @@ Many clients can write to the same log. Records are written in sequence number o
 
 If you have a heterogeneous set of hardware, you can configure weights for storage and sequencer nodes in the node configuration. The weight values are used to balance APPENDs across sequencer nodes and STOREs across storage nodes.
 
-* `storage_weight` defines the amount of data to be stored compared to other machines. You should assign weights to systems according to their relative disk size.
+* `storage_capacity` defines the amount of data to be stored compared to other machines. You should assign weights to systems according to their relative disk size.
 * `sequencer_weight` is used when determining number of sequencers to be placed on a node. Assign a larger weight to the nodes with the fastest hardware / most memory.
 
-[See how to configure `sequencer_weight` and `storage_weight`.](configuration.md#roles-and-state-roles-sequencer-sequencer_weight-storage-and-storage_weight)
+[See how to configure `sequencer_weight` and `storage_capacity`.](configuration.md#roles-and-state-roles-sequencer-sequencer_weight-storage-and-storage_capacity)
 
 ### Load balancing across logs
 

--- a/website/versioned_docs/version-2.46.5/configuration.md
+++ b/website/versioned_docs/version-2.46.5/configuration.md
@@ -113,7 +113,7 @@ Nodes is an array of node objects. An example node object would be:
     ],
     "sequencer": true,
     "storage": "read-write",
-    "storage_weight": 2,
+    "storage_capacity": 2,
     "location": "abc.def.gh.ij.kl",
     "node_id": 0,
     "num_shards": 15,
@@ -145,7 +145,7 @@ can be placed on machines with 3 different rack identifiers (but could share sam
 
 Each section can be expressed as a string.
 
-### Roles and state (`roles`, `sequencer`, `sequencer_weight`, `storage` and `storage_weight`)
+### Roles and state (`roles`, `sequencer`, `sequencer_weight`, `storage` and `storage_capacity`)
 A distinction should be made between roles and state:
 - Role: this remains the same during the lifetime of the node.
 - State: could change (for e.g. maintenance operations)
@@ -155,7 +155,7 @@ A distinction should be made between roles and state:
 - `sequencer`
 - `storage`
 
-`storage_weight` defines a proportional value for the amount of data to be stored compared to other machines. When e.g. total disk size is used as weight for machines with variable disk sizes, the storage will be used proportionally.
+`storage_capacity` defines a proportional value for the amount of data to be stored compared to other machines. When e.g. total disk size is used as weight for machines with variable disk sizes, the storage will be used proportionally.
 `sequencer_weight` can similarly define a proportional value for the number of sequencers to be placed on the machine.
 
 #### State


### PR DESCRIPTION
storage_weight -> storage_capacity in both the current and legacy docs.

Fixes #174