### PR TITLE
Fix open source build by linking against libthriftmetadata.so

### DIFF
--- a/logdevice/CMake/build-fbthrift.cmake
+++ b/logdevice/CMake/build-fbthrift.cmake
@@ -52,6 +52,7 @@ set(FBTHRIFT_LIBRARIES
     ${BINARY_DIR}/lib/libcompiler_base.so
     ${BINARY_DIR}/lib/libthriftprotocol.so
     ${BINARY_DIR}/lib/libconcurrency.so
+    ${BINARY_DIR}/lib/libthriftmetadata.so
 )
 
 set(FBTHRIFT_INCLUDE_DIR

--- a/logdevice/admin/if/CMakeLists.txt
+++ b/logdevice/admin/if/CMakeLists.txt
@@ -57,7 +57,7 @@ foreach(THRIFT_SOURCE
   )
 
   add_dependencies(${THRIFT_SOURCE}-cpp2-target fbthrift)
-  target_link_libraries(${THRIFT_SOURCE}-cpp2 common-cpp2)
+  target_link_libraries(${THRIFT_SOURCE}-cpp2 common-cpp2 Membership-cpp2)
 
   if(thriftpy3)
     target_link_libraries(


### PR DESCRIPTION
Summary:
Fix OSS build error:

```
/usr/bin/ld: ../../lib/libadmin-cpp2.a(admin_metadata.cpp.o): undefined reference to symbol '_ZNKR6apache6thrift8metadata20ThriftServiceContext16get_service_infoEv'
//root/project/_build/fbthrift-prefix/src/fbthrift-build/lib/libthriftmetadata.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Differential Revision: D20257545

