### PR TITLE
Boost_FOUND was set even when Boost::python is not found

### DIFF
--- a/logdevice/CMake/logdevice-deps.cmake
+++ b/logdevice/CMake/logdevice-deps.cmake
@@ -31,8 +31,8 @@ foreach(_boost_py_component ${_boost_py_component1} ${_boost_py_component2} ${_b
     thread
     ${_boost_py_component})
 
-
-  if(Boost_FOUND)
+  string(TOUPPER ${_boost_py_component} _BOOST_PY_COMP)
+  if(Boost_${_BOOST_PY_COMP}_FOUND)
     message(STATUS "Boost Python Component ${_boost_py_component} found")
     break()
   else()
@@ -40,7 +40,7 @@ foreach(_boost_py_component ${_boost_py_component1} ${_boost_py_component2} ${_b
   endif()
 endforeach()
 
-if(NOT Boost_FOUND)
+if(NOT Boost_${_BOOST_PY_COMP}_FOUND)
   message(FATAL_ERROR "Couldn't find any Boost python component. At least one is required, terminating. ${Boost_ERROR_REASON}")
 endif()
 


### PR DESCRIPTION
During my compilation, I found strange things that tough it was said
Boost_FOUND, the Boost_LIBRARIES actually doesn't contain Boost::python
or Boost::pythonxy.

After checking
https://cmake.org/cmake/help/latest/module/FindBoost.html, I found that
it would be better if we use `Boost_<PY_COMP>_FOUND`, if Boost::python is a must
to our environment.

I don't know if this check is stronger than Boost_FOUND, for example,
maybe Boost::context is not found, but Boost_FOUND is still set to true
and `Boost_<PY_COMP>_FOUND` is also set to true. But for now, I'd think
`Boost_<PY_COMP>_FOUND` implies Boost_FOUND.