### PR TITLE
Adding config in server settings to ignore client's DSCP value

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -235,6 +235,7 @@ sidebar_label: Settings
 | connect-timeout-retry-multiplier | Multiplier that is applied to the connect timeout after every failed connection attempt | 3 |  |
 | connection-backlog | (server-only setting) Maximum number of incoming connections that have been accepted by listener (have an open FD) but have not been processed by workers (made logdevice protocol handshake). | 2000 | server&nbsp;only |
 | connection-retries | the number of TCP connection retries before giving up | 4 |  |
+| enable-dscp-reflection | If enabled, server will use DSCP TypeOfService used by client for communicationoIf disabled, server will use default DSCP value  | true | requires&nbsp;restart, server&nbsp;only |
 | handshake-timeout | LogDevice protocol handshake timeout | 1s |  |
 | include-destination-on-handshake | Include the destination node ID in the LogDevice protocol handshake. If the actual node ID of the connection target does not match the intended destination ID, the connection is terminated. | true |  |
 | incoming-messages-max-bytes-limit | maximum byte limit of unprocessed messages within the system. | 524288000 | requires&nbsp;restart |

--- a/logdevice/server/ConnectionListener.cpp
+++ b/logdevice/server/ConnectionListener.cpp
@@ -29,8 +29,9 @@ ConnectionListener::ConnectionListener(
     KeepAlive loop,
     std::shared_ptr<SharedState> shared_state,
     ListenerType listener_type,
-    ResourceBudget& connection_backlog_budget)
-    : Listener(std::move(iface), loop),
+    ResourceBudget& connection_backlog_budget,
+    bool enable_dscp_reflection)
+    : Listener(std::move(iface), loop, enable_dscp_reflection),
       loop_(loop),
       connection_backlog_budget_(connection_backlog_budget),
       shared_state_(shared_state),

--- a/logdevice/server/ConnectionListener.h
+++ b/logdevice/server/ConnectionListener.h
@@ -56,7 +56,8 @@ class ConnectionListener : public Listener {
                               KeepAlive loop,
                               std::shared_ptr<SharedState> shared_state,
                               ListenerType listener_type,
-                              ResourceBudget& connection_backlog_budget);
+                              ResourceBudget& connection_backlog_budget,
+                              bool enable_dscp_reflection);
 
   void setProcessor(Processor* processor) {
     processor_ = processor;

--- a/logdevice/server/Listener.cpp
+++ b/logdevice/server/Listener.cpp
@@ -22,8 +22,9 @@ bool Listener::isSSL() const {
   return iface_.isSSL();
 }
 
-Listener::Listener(const InterfaceDef& iface, KeepAlive loop)
-    : iface_(iface), loop_(loop) {
+Listener::
+Listener(const InterfaceDef& iface, KeepAlive loop, bool enable_dscp_reflection)
+    : iface_(iface), loop_(loop), enable_dscp_reflection_(enable_dscp_reflection){
   ld_info("Created Listener: %s", iface.describe().c_str());
 }
 
@@ -67,7 +68,7 @@ bool Listener::setupAsyncSocket() {
     socket->addAcceptCallback(this, nullptr);
     socket->listen(128);
 
-    if (socket->getAddress().getFamily() != AF_UNIX) {
+    if (enable_dscp_reflection_ && socket->getAddress().getFamily() != AF_UNIX) {
       socket->setTosReflect(true);
     }
 

--- a/logdevice/server/Listener.h
+++ b/logdevice/server/Listener.h
@@ -90,7 +90,7 @@ class Listener : public folly::AsyncServerSocket::AcceptCallback {
     bool ssl_;
   };
 
-  explicit Listener(const InterfaceDef& iface, KeepAlive loop);
+  explicit Listener(const InterfaceDef& iface, KeepAlive loop, bool enable_dscp_reflection);
 
   virtual ~Listener();
 
@@ -133,6 +133,9 @@ class Listener : public folly::AsyncServerSocket::AcceptCallback {
 
   // EventLoop on which listener is running
   KeepAlive loop_;
+
+  // Whether to use DSCP value provided by client
+  bool enable_dscp_reflection_;
 
   // Must be accessed only from evenloop thread
   std::shared_ptr<folly::AsyncServerSocket> socket_;

--- a/logdevice/server/Server.cpp
+++ b/logdevice/server/Server.cpp
@@ -701,7 +701,8 @@ bool Server::initListeners() {
         folly::getKeepAliveToken(connection_listener_loop_->getEventBase()),
         conn_shared_state,
         ConnectionListener::ListenerType::DATA,
-        conn_budget_backlog_);
+        conn_budget_backlog_,
+        server_settings_->enable_dscp_reflection);
 
     auto nodes_configuration = updateable_config_->getNodesConfiguration();
     ld_check(nodes_configuration);
@@ -757,7 +758,8 @@ bool Server::initListeners() {
                 ssl_connection_listener_loop_->getEventBase()),
             conn_shared_state,
             ConnectionListener::ListenerType::DATA_SSL,
-            conn_budget_backlog_);
+            conn_budget_backlog_,
+            server_settings_->enable_dscp_reflection);
       }
     }
 
@@ -797,7 +799,8 @@ bool Server::initListeners() {
             folly::getKeepAliveToken(gossip_listener_loop_->getEventBase()),
             conn_shared_state,
             ConnectionListener::ListenerType::GOSSIP,
-            conn_budget_backlog_unlimited_);
+            conn_budget_backlog_unlimited_,
+            server_settings_->enable_dscp_reflection);
       }
     } else {
       ld_info("Gossip listener initialization not required"
@@ -833,7 +836,8 @@ bool Server::initListeners() {
               server_to_server_listener_loop_->getEventBase()),
           conn_shared_state,
           ConnectionListener::ListenerType::SERVER_TO_SERVER,
-          conn_budget_backlog_unlimited_);
+          conn_budget_backlog_unlimited_,
+          server_settings_->enable_dscp_reflection);
     }
 
   } catch (const ConstructorFailed&) {

--- a/logdevice/server/ServerSettings.cpp
+++ b/logdevice/server/ServerSettings.cpp
@@ -582,6 +582,14 @@ void ServerSettings::defineSettings(SettingEasyInit& init) {
      SERVER | REQUIRES_RESTART,
      SettingsCategory::Configuration)
 
+    ("enable-dscp-reflection",
+     &enable_dscp_reflection,
+     "true",
+     nullptr,
+     "If enabled, server will use DSCP TypeOfService used by client for communicationo"
+     "If disabled, server will use default DSCP value ",
+     SERVER | REQUIRES_RESTART,
+     SettingsCategory::Network)
     ;
   // clang-format on
 

--- a/logdevice/server/ServerSettings.h
+++ b/logdevice/server/ServerSettings.h
@@ -108,6 +108,8 @@ struct ServerSettings : public SettingsBundle {
   bool use_tls_ticket_seeds;
   std::string tls_ticket_seeds_path;
 
+  bool enable_dscp_reflection;
+
  private:
   // Only UpdateableSettings can create this bundle to ensure defaults are
   // populated.

--- a/logdevice/server/test/UnreleasedRecordDetectorTest.cpp
+++ b/logdevice/server/test/UnreleasedRecordDetectorTest.cpp
@@ -257,7 +257,8 @@ void UnreleasedRecordDetectorTest::SetUp() {
       folly::getKeepAliveToken(connection_listener_loop_->getEventBase()),
       std::make_shared<ConnectionListener::SharedState>(),
       ConnectionListener::ListenerType::DATA,
-      budget_);
+      budget_,
+      /* enable_dscp_reflection= */ true);
   connection_listener_->setProcessor(processor_.get());
   ld_notify("ConnectionListener created.");
 


### PR DESCRIPTION
Adding new server setting "use_client_provided_tos" of bool type (default true), when disabled the server ignores DSCP value provided by client.

Testing done:
Used wireshark to intercept the packets and check that server uses its own default value when use_client_provided_tos is set to false.
When set to true, the server uses same DSCP value to communicate with the client as provided by the client