### PR TITLE
Add directory query support to ldshell sql query

### DIFF
--- a/logdevice/CMakeLists.txt
+++ b/logdevice/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories("${LOGDEVICE_STAGING_DIR}/usr/include/")
 include_directories("${LOGDEVICE_STAGING_DIR}/usr/local/include/")
 
 set(PACKAGE_NAME "logdevice")

--- a/logdevice/ops/ldquery/LDQuery.cpp
+++ b/logdevice/ops/ldquery/LDQuery.cpp
@@ -31,6 +31,7 @@
 #include "tables/InfoRsm.h"
 #include "tables/Iterators.h"
 #include "tables/LogGroups.h"
+#include "tables/LogDirectories.h"
 #include "tables/LogRebuildings.h"
 #include "tables/LogStorageState.h"
 #include "tables/LogsConfigRsm.h"
@@ -158,6 +159,7 @@ LDQuery::LDQuery(std::string config_path,
   table_registry_.registerTable<tables::InfoRsm>(ctx_);
   table_registry_.registerTable<tables::Iterators>(ctx_);
   table_registry_.registerTable<tables::LogGroups>(ctx_);
+  table_registry_.registerTable<tables::LogDirectories>(ctx_);
   table_registry_.registerTable<tables::LogRebuildings>(ctx_);
   table_registry_.registerTable<tables::LogStorageState>(ctx_);
   table_registry_.registerTable<tables::LogsConfigRsm>(ctx_);

--- a/logdevice/ops/ldquery/Table.cpp
+++ b/logdevice/ops/ldquery/Table.cpp
@@ -179,6 +179,13 @@ bool Table::columnHasEqualityConstraint(int col,
   return columnhasconstraint(col, SQLITE_INDEX_CONSTRAINT_EQ, ctx, expr);
 }
 
+bool Table::columnHasLikeConstraint(int col,
+                                 QueryContext& ctx,
+                                 std::string& expr) const {
+  return columnhasconstraint(col, SQLITE_INDEX_CONSTRAINT_LIKE, ctx, expr);
+}
+
+
 bool Table::columnHasEqualityConstraintOnLogid(int col,
                                                QueryContext& ctx,
                                                logid_t& logid) const {

--- a/logdevice/ops/ldquery/Table.h
+++ b/logdevice/ops/ldquery/Table.h
@@ -252,6 +252,9 @@ class Table {
   bool columnHasEqualityConstraint(int col,
                                    QueryContext& ctx,
                                    std::string& expr) const;
+  bool columnHasLikeConstraint(int col,
+                             QueryContext& ctx,
+                             std::string& expr) const;
 
   /**
    * Checks if there is an equality constraint on column `col` for a log id.

--- a/logdevice/ops/ldquery/Utils.cpp
+++ b/logdevice/ops/ldquery/Utils.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 #include "logdevice/ops/ldquery/Utils.h"
+#include "logdevice/common/debug.h"
 
 namespace facebook { namespace logdevice { namespace ldquery {
 
@@ -23,6 +24,87 @@ std::string s(const folly::Optional<std::chrono::seconds>& val) {
 
 std::string s(const folly::Optional<std::chrono::milliseconds>& val) {
   return s(val ? val->count() : 0);
+}
+
+
+bool match_likexpr(std::string str, std::string likexpr) {
+
+  ld_debug("str '%s', likexpr '%s'", str.c_str(), likexpr.c_str());
+  // expr_index
+  int ei = 0;
+  int ej = 0;
+  // str_index
+  int si = 0;
+  int sj = 0;
+
+  bool has_percentage = false;
+  size_t underscore_num = 0;
+  std::string word;
+  std::string wcards;
+
+  while (ei < likexpr.size()) {
+    ej = likexpr.find_first_of("%_", ei);
+    if (ei == ej) {
+      // entered wildcards subpart, like %%, %_, _%, etc
+      // setup match conditions and continue the loop
+      while(likexpr[ei] == '%' || likexpr[ei] == '_') {
+        if (likexpr[ei] == '%') {
+          has_percentage = true;
+        }
+        if (likexpr[ei] == '_') {
+          underscore_num++;
+        }
+        ei++;
+      }
+    } else {
+      // entered normal word subpart, like abc, cbd, etc
+      // try to match the subword and contine the loop
+      std::string to_match = ej == std::string::npos?
+        likexpr.substr(ei) : likexpr.substr(ei, ej - ei);
+
+      ld_debug("subword to match: '%s', has_percentage: %s, underscore_num: %d",
+              to_match.c_str(), has_percentage? "true" : "false", underscore_num);
+
+      // try matching
+      // 1. skip the underscore_num of chars
+      si += underscore_num;
+      underscore_num = 0;
+
+      // 2. find the matched substr
+      if (has_percentage) {
+        ld_debug("try to find '%s' from index %d", to_match.c_str(), si);
+        sj = str.find(to_match, si);
+        if (sj == std::string::npos) {
+          return false;
+        }
+        has_percentage = false;
+      } else {
+        ld_debug("try to match '%s' from %d", to_match.c_str(), si);
+        if (!str.rfind(to_match, si) == si) {
+          return false;
+        }
+      }
+
+      // 3. update indexes
+      // avoid to use ej directly
+      si = sj + to_match.size();
+      ei += to_match.size();
+    }
+  }
+
+  si += underscore_num;
+  if (si == str.size()) {
+    return true;
+  } else if (si > str.size()) {
+    return false;
+  } else if (has_percentage) {
+    // si < str.size() and has_percentage
+    return true;
+  } else {
+    // si < str.size() and there is no percentage symbol
+    return false;
+  }
+
 }
 
 }}} // namespace facebook::logdevice::ldquery

--- a/logdevice/ops/ldquery/Utils.h
+++ b/logdevice/ops/ldquery/Utils.h
@@ -31,4 +31,6 @@ std::string s(const folly::Optional<std::chrono::seconds>& val);
 
 std::string s(const folly::Optional<std::chrono::milliseconds>& val);
 
+bool match_likexpr(std::string str, std::string likexpr);
+
 }}} // namespace facebook::logdevice::ldquery

--- a/logdevice/ops/ldquery/tables/LogDirectories.cpp
+++ b/logdevice/ops/ldquery/tables/LogDirectories.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include "logdevice/ops/ldquery/tables/LogDirectories.h"
+
+#include <queue>
+#include <folly/Conv.h>
+#include <folly/json.h>
+
+#include "../Table.h"
+#include "../Utils.h"
+#include "LogTreeBase.h"
+
+#include "logdevice/common/configuration/Configuration.h"
+#include "logdevice/common/configuration/ReplicationProperty.h"
+#include "logdevice/common/configuration/UpdateableConfig.h"
+#include "logdevice/common/debug.h"
+#include "logdevice/lib/ClientImpl.h"
+
+
+namespace facebook {
+  namespace logdevice {
+    namespace ldquery {
+      namespace tables {
+
+TableColumns LogDirectories::getColumns() const {
+  return LogTreeBase::getAttributeColumns();
+}
+
+std::shared_ptr<TableData> LogDirectories::getData(QueryContext& ctx) {
+  auto result = std::make_shared<TableData>();
+  auto client = ld_ctx_->getFullClient();
+
+  ld_check(client);
+
+  auto add_row =
+      [&](client::Directory* dir, const std::string path) {
+    auto dir_attrs = dir->attrs();
+
+    // This should remain the first ColumnValue as expected by the code below.
+    result->cols["parent_dir"].push_back(path);
+    result->cols["name"].push_back(dir->getFullyQualifiedName());
+    result->cols["logid_lo"].push_back(std::string("0"));
+    result->cols["logid_hi"].push_back(std::string("0"));
+
+    LogTreeBase::populateAttributeData(*result, dir_attrs);
+  };
+
+  // If the query contains a constraint on the directory name, we can efficiently
+  // find the directory using getDirectorySync().
+  std::string expr;
+  if (columnHasEqualityConstraint(10, ctx, expr)) {
+      auto parent_dir = client->getDirectorySync(expr);
+      if (parent_dir) {
+          const client::DirectoryMap& children = parent_dir->children();
+          for (auto& dir_pair : children) {
+              add_row(dir_pair.second.get(), parent_dir->getFullyQualifiedName());
+          }
+      }
+  } else if (columnHasEqualityConstraint(0, ctx, expr)) {
+    auto dir = client->getDirectorySync(expr);
+    if (dir) {
+      add_row(dir.get(), dir->parent()->getFullyQualifiedName());
+    }
+  } else if (columnHasLikeConstraint(0, ctx, expr)) {
+      std::unique_ptr<client::Directory> root_dir
+          = client->getDirectorySync(
+                client->getLogNamespaceDelimiter());
+
+      if (match_likexpr(root_dir->getFullyQualifiedName(), expr)) {
+          add_row(root_dir.get(), "");
+      }
+      std::queue<client::Directory*> dir_q;
+      dir_q.push(root_dir.get());
+
+      while (!dir_q.empty()) {
+          client::Directory* parent_dir = dir_q.front();
+          dir_q.pop();
+          for (const auto& dir_pair: parent_dir->children()) {
+              if (match_likexpr(dir_pair.second->getFullyQualifiedName(), expr)) {
+                add_row(dir_pair.second.get(), parent_dir->getFullyQualifiedName());
+              }
+              dir_q.push(dir_pair.second.get());
+          }
+      }
+  } else {
+      std::unique_ptr<client::Directory> root_dir
+          = client->getDirectorySync(
+              client->getLogNamespaceDelimiter());
+
+      add_row(root_dir.get(), "");
+      std::queue<client::Directory*> dir_q;
+      dir_q.push(root_dir.get());
+
+      while (!dir_q.empty()) {
+          client::Directory* parent_dir = dir_q.front();
+          dir_q.pop();
+          for (const auto& dir_pair: parent_dir->children()) {
+              add_row(dir_pair.second.get(), parent_dir->getFullyQualifiedName());
+              dir_q.push(dir_pair.second.get());
+          }
+      }
+  }
+
+  return result;
+}
+
+}}}} // namespace facebook::logdevice::ldquery::tables

--- a/logdevice/ops/ldquery/tables/LogDirectories.h
+++ b/logdevice/ops/ldquery/tables/LogDirectories.h
@@ -13,21 +13,20 @@
 #include "../Context.h"
 #include "../Table.h"
 
-
 namespace facebook {
   namespace logdevice {
     namespace ldquery {
       namespace tables {
 
-class LogGroups : public Table {
+class LogDirectories : public Table {
  public:
-  explicit LogGroups(std::shared_ptr<Context> ctx) : Table(ctx) {}
+  explicit LogDirectories(std::shared_ptr<Context> ctx) : Table(ctx) {}
   static std::string getName() {
-    return "log_groups";
+    return "log_dirs";
   }
   std::string getDescription() override {
-    return "A table that lists the log groups configured in the cluster.  A log"
-           " group is an interval of log ids that share common configuration "
+    return "A table that lists the directories configured in the cluster.  A "
+           "directory is a namespace that share common configuration "
            "property.";
   }
   TableColumns getColumns() const override;

--- a/logdevice/ops/ldquery/tables/LogGroups.cpp
+++ b/logdevice/ops/ldquery/tables/LogGroups.cpp
@@ -12,6 +12,8 @@
 
 #include "../Table.h"
 #include "../Utils.h"
+#include "LogTreeBase.h"
+
 #include "logdevice/common/configuration/Configuration.h"
 #include "logdevice/common/configuration/ReplicationProperty.h"
 #include "logdevice/common/configuration/UpdateableConfig.h"
@@ -25,50 +27,7 @@ namespace facebook {
       namespace tables {
 
 TableColumns LogGroups::getColumns() const {
-  return {
-      {"name", DataType::TEXT, "Name of the log group."},
-      {"logid_lo",
-       DataType::LOGID,
-       "Defines the lower bound (inclusive) of the range of log ids in this "
-       "log group."},
-      {"logid_hi",
-       DataType::LOGID,
-       "Defines the upper bound (inclusive) of the range of log ids in this "
-       "log group."},
-      {"replication_property",
-       DataType::TEXT,
-       "Replication property configured for this log group."},
-      {"synced_copies",
-       DataType::INTEGER,
-       "Number of copies that must be acknowledged by storage nodes are synced "
-       "to disk before the record is acknowledged to the client as fully "
-       "appended."},
-      {"max_writes_in_flight",
-       DataType::INTEGER,
-       "The largest number of records not released for delivery that the "
-       "sequencer allows to be outstanding."},
-      {"backlog_duration_sec",
-       DataType::INTEGER,
-       "Time-based retention of records of logs in that log group.  If null or "
-       "zero, this log group does not use time-based retention."},
-      {"storage_set_size",
-       DataType::INTEGER,
-       "Size of the storage set for logs in that log group.  The storage set "
-       "is the set of shards that may hold data for a log."},
-      {"delivery_latency",
-       DataType::INTEGER,
-       "For logs in that log group, maximum amount of time that we can delay "
-       "delivery of newly written records.  This option increases delivery "
-       "latency but improves server and client performance."},
-      {"scd_enabled",
-       DataType::INTEGER,
-       "Indicates whether the Single Copy Delivery optimization is enabled for "
-       "this log group.  This efficiency optimization allows only one copy of "
-       "each record to be served to readers."},
-      {"custom_fields",
-       DataType::TEXT,
-       "Custom text field provided by the user."},
-  };
+  return LogTreeBase::getAttributeColumns();
 }
 
 std::shared_ptr<TableData> LogGroups::getData(QueryContext& ctx) {
@@ -84,32 +43,13 @@ std::shared_ptr<TableData> LogGroups::getData(QueryContext& ctx) {
     ld_check(log);
     auto log_attrs = log->attrs();
 
-    ColumnValue custom;
-    if (log_attrs.extras().hasValue() && (*log_attrs.extras()).size() > 0) {
-      folly::dynamic extra_attrs = folly::dynamic::object;
-      for (const auto& it : log_attrs.extras().value()) {
-        extra_attrs[it.first] = it.second;
-      }
-      custom = folly::toJson(extra_attrs);
-    }
-
-    ReplicationProperty rprop =
-        ReplicationProperty::fromLogAttributes(log_attrs);
     // This should remain the first ColumnValue as expected by the code below.
     result->cols["name"].push_back(name);
 
     result->cols["logid_lo"].push_back(s(range.first.val_));
     result->cols["logid_hi"].push_back(s(range.second.val_));
-    result->cols["replication_property"].push_back(rprop.toString());
-    result->cols["synced_copies"].push_back(s(*log_attrs.syncedCopies()));
-    result->cols["max_writes_in_flight"].push_back(
-        s(*log_attrs.maxWritesInFlight()));
-    result->cols["backlog_duration_sec"].push_back(
-        s(*log_attrs.backlogDuration()));
-    result->cols["storage_set_size"].push_back(s(*log_attrs.nodeSetSize()));
-    result->cols["delivery_latency"].push_back(s(*log_attrs.deliveryLatency()));
-    result->cols["scd_enabled"].push_back(s(*log_attrs.scdEnabled()));
-    result->cols["custom_fields"].push_back(custom);
+    LogTreeBase::populateAttributeData(*result, log_attrs);
+
   };
 
   // If the query contains a constraint on the group name, we can efficiently

--- a/logdevice/ops/ldquery/tables/LogTreeBase.cpp
+++ b/logdevice/ops/ldquery/tables/LogTreeBase.cpp
@@ -1,0 +1,81 @@
+#include "LogTreeBase.h"
+#include <folly/Conv.h>
+#include <folly/json.h>
+#include "../Utils.h"
+#include "logdevice/common/configuration/ReplicationProperty.h"
+
+namespace facebook::logdevice::ldquery::tables {
+
+TableColumns LogTreeBase::getAttributeColumns() {
+  return {
+      {"name", DataType::TEXT, "Name of the log group or the directory."},
+      {"logid_lo", DataType::LOGID,
+       "Defines the lower bound (inclusive) of the range of log ids in this "
+       "log group."},
+      {"logid_hi",
+       DataType::LOGID,
+       "Defines the upper bound (inclusive) of the range of log ids in this "
+       "log group."},
+      {"replication_property",
+       DataType::TEXT,
+       "Replication property configured for this log group."},
+      {"synced_copies",
+       DataType::INTEGER,
+       "Number of copies that must be acknowledged by storage nodes are synced "
+       "to disk before the record is acknowledged to the client as fully "
+       "appended."},
+      {"max_writes_in_flight",
+       DataType::INTEGER,
+       "The largest number of records not released for delivery that the "
+       "sequencer allows to be outstanding."},
+      {"backlog_duration_sec",
+       DataType::INTEGER,
+       "Time-based retention of records of logs in that log group.  If null or "
+       "zero, this log group does not use time-based retention."},
+      {"storage_set_size",
+       DataType::INTEGER,
+       "Size of the storage set for logs in that log group.  The storage set "
+       "is the set of shards that may hold data for a log."},
+      {"delivery_latency",
+       DataType::INTEGER,
+       "For logs in that log group, maximum amount of time that we can delay "
+       "delivery of newly written records.  This option increases delivery "
+       "latency but improves server and client performance."},
+      {"scd_enabled",
+       DataType::INTEGER,
+       "Indicates whether the Single Copy Delivery optimization is enabled for "
+       "this log group.  This efficiency optimization allows only one copy of "
+       "each record to be served to readers."},
+      {"parent_dir", DataType::TEXT, "Name of the parent directory."},
+      {"custom_fields",
+       DataType::TEXT,
+       "Custom text field provided by the user."},
+  };
+}
+
+void LogTreeBase::populateAttributeData(TableData& tab_data, const facebook::logdevice::logsconfig::LogAttributes& log_attrs) {
+    ColumnValue custom;
+    if (log_attrs.extras().hasValue() && (*log_attrs.extras()).size() > 0) {
+      folly::dynamic extra_attrs = folly::dynamic::object;
+      for (const auto& it : log_attrs.extras().value()) {
+        extra_attrs[it.first] = it.second;
+      }
+      custom = folly::toJson(extra_attrs);
+    }
+
+    ReplicationProperty rprop =
+        ReplicationProperty::fromLogAttributes(log_attrs);
+    // This should remain the first ColumnValue as expected by the code below.
+    tab_data.cols["replication_property"].push_back(rprop.toString());
+    tab_data.cols["synced_copies"].push_back(s(*log_attrs.syncedCopies()));
+    tab_data.cols["max_writes_in_flight"].push_back(
+        s(*log_attrs.maxWritesInFlight()));
+    tab_data.cols["backlog_duration_sec"].push_back(
+        s(*log_attrs.backlogDuration()));
+    tab_data.cols["storage_set_size"].push_back(s(*log_attrs.nodeSetSize()));
+    tab_data.cols["delivery_latency"].push_back(s(*log_attrs.deliveryLatency()));
+    tab_data.cols["scd_enabled"].push_back(s(*log_attrs.scdEnabled()));
+    tab_data.cols["custom_fields"].push_back(custom);
+}
+
+}

--- a/logdevice/ops/ldquery/tables/LogTreeBase.h
+++ b/logdevice/ops/ldquery/tables/LogTreeBase.h
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+
+#include <map>
+#include <vector>
+
+#include "../Context.h"
+#include "../Table.h"
+
+namespace facebook::logdevice::logsconfig {
+class LogAttributes;
+}
+
+namespace facebook::logdevice::ldquery::tables {
+
+class LogTreeBase {
+public:
+  static TableColumns getAttributeColumns();
+  static void populateAttributeData(TableData&, const facebook::logdevice::logsconfig::LogAttributes& attrs);
+};
+
+
+
+} // namespace facebook::logdevice::ldquery::tables


### PR DESCRIPTION
We found loggroup can be queried through sql, but directories cannot be queried with sql.

So we added a support of sql query for directories.

The result of "select * from dirs where path='/a/b/c'" will list children of /a/b/c

The result of "select * from dirs" will list all directories.

please kindly check if this could be a desired change.