### PR TITLE
Changes to pick same server from a client instance for every config fetch call

### DIFF
--- a/logdevice/common/NodesConfigurationPoller.cpp
+++ b/logdevice/common/NodesConfigurationPoller.cpp
@@ -22,12 +22,14 @@ NodesConfigurationPoller::NodesConfigurationPoller(
     Poller::Options options,
     VersionExtFn version_fn,
     Callback cb,
+    folly::Optional<u_int32_t> node_order_seed,
     folly::Optional<Version> conditional_base_version)
     : options_(std::move(options)),
       version_fn_(std::move(version_fn)),
       cb_(std::move(cb)),
       conditional_base_version_(std::move(conditional_base_version)),
-      callback_helper_(this) {
+      callback_helper_(this),
+      node_order_seed_(node_order_seed) {
   ld_check(version_fn_ != nullptr);
   ld_check(cb_ != nullptr);
 }
@@ -76,6 +78,7 @@ NodesConfigurationPoller::createPoller() {
                                       graylist,
                                       num_required,
                                       num_extras,
+                                      node_order_seed_,
                                       cluster_state);
   };
 

--- a/logdevice/common/NodesConfigurationPoller.h
+++ b/logdevice/common/NodesConfigurationPoller.h
@@ -21,7 +21,10 @@ namespace facebook { namespace logdevice {
 class ClusterState;
 
 // an instantiation of ObjectPoller which can be used to poll NodesConfiguration
-// updates from existing server nodes in NodesConfiguration
+// updates from existing server nodes in NodesConfiguration.
+// If the same seed is provided to the NodesConfigurationPoller, the same set of servers will be picked for the polling round. 
+// This can be used to implement stickiness in the polling set.
+
 class NodesConfigurationPoller {
  public:
   struct NodeResponse {
@@ -49,6 +52,7 @@ class NodesConfigurationPoller {
       Poller::Options options,
       VersionExtFn version_fn,
       Callback cb,
+      folly::Optional<u_int32_t> node_order_seed,
       folly::Optional<Version> conditional_base_version = {});
   virtual ~NodesConfigurationPoller() {}
 
@@ -89,6 +93,10 @@ class NodesConfigurationPoller {
 
   // used to re-route the ConfigurationFetchRequest result callback
   WorkerCallbackHelper<NodesConfigurationPoller> callback_helper_;
+
+  // We have one seed per ServerBasedNodesConfigurationManager instance to ensure total ordering
+  // among nodes to be picked for fetching config
+  folly::Optional<u_int32_t> node_order_seed_;
 
   std::unique_ptr<Poller> createPoller();
 

--- a/logdevice/common/RandomNodeSelector.h
+++ b/logdevice/common/RandomNodeSelector.h
@@ -32,6 +32,7 @@ class RandomNodeSelector {
                               const NodeSourceSet& graylist,
                               size_t num_required,
                               size_t num_extras,
+                              folly::Optional<u_int32_t> node_order_seed,
                               ClusterState* cluster_state_filter = nullptr);
 
   /**

--- a/logdevice/common/configuration/nodes/ServerBasedNodesConfigurationStore.h
+++ b/logdevice/common/configuration/nodes/ServerBasedNodesConfigurationStore.h
@@ -24,6 +24,7 @@ namespace configuration { namespace nodes {
 // is fetched from random servers in the cluster.
 class ServerBasedNodesConfigurationStore : public NodesConfigurationStore {
  public:
+  ServerBasedNodesConfigurationStore();
   ~ServerBasedNodesConfigurationStore() override = default;
 
   // Enqueues a ConfigurationFetchRequest request of type NodesConfiguration on
@@ -67,6 +68,7 @@ class ServerBasedNodesConfigurationStore : public NodesConfigurationStore {
 
  private:
   std::atomic<bool> shutdown_signaled_{false};
+  folly::Optional<u_int32_t> node_order_seed_;
 
   // helper utility to generate a polling option based on processor
   // settings and existing nodes configuration


### PR DESCRIPTION
Added a seed which is initialized when ServerBasedNodesConfigurationProvider object is instantiated and is passed everytime to ensure that server nodes are picked in same order everytime while trying to fetch config