### PR TITLE
Migrate AdminCommandAPIHandler to use coroutines

### DIFF
--- a/logdevice/admin/CheckImpactHandler.h
+++ b/logdevice/admin/CheckImpactHandler.h
@@ -19,8 +19,7 @@ namespace facebook { namespace logdevice {
 class CheckImpactHandler : public virtual AdminAPIHandlerBase {
  public:
   // check admin.thrift for documentation
-  virtual folly::SemiFuture<std::unique_ptr<thrift::CheckImpactResponse>>
-  semifuture_checkImpact(
-      std::unique_ptr<thrift::CheckImpactRequest> request) override;
+  virtual folly::coro::Task<std::unique_ptr<thrift::CheckImpactResponse>>
+  co_checkImpact(std::unique_ptr<thrift::CheckImpactRequest> request) override;
 };
 }} // namespace facebook::logdevice


### PR DESCRIPTION
Summary: Now that we have coroutines support, let's try migrating the first part of our codebase to coroutines.

Differential Revision: D22839103

