### PR TITLE
Fix warnings about installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ source ./staging/usr/local/bin/activate
 > `source ./staging/usr/local/bin/activate`
 
 ```shell-session
-python3 -m pip install --upgrade setuptools wheel cython==0.28.6
+python3 -m pip install --upgrade setuptools wheel cython
 ```
 
 ## Start the build


### PR DESCRIPTION
**Environment:**
:~/LogDevice/_build$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.5 LTS
Release:        18.04
Codename:       bionic

:~/LogDevice/_build$ git show --oneline -s
843d9ad0 (HEAD -> master, origin/master, origin/HEAD) Updating submodules

**Warning Summary:**
python3 -m pip install --upgrade setuptools wheel cython==0.28.6
Collecting setuptools
Using cached setuptools-50.3.0-py3-none-any.whl (785 kB)
  Requirement already up-to-date: wheel in
  ./staging/usr/local/lib/python3.6/site-packages (0.35.1)
  Collecting cython==0.28.6
  Using cached Cython-0.28.6-cp36-cp36m-manylinux1_x86_64.whl (3.4 MB)
  Installing collected packages: setuptools, cython
  Attempting uninstall: setuptools
  Found existing installation: setuptools 49.6.0
  Uninstalling setuptools-49.6.0:
  Successfully uninstalled setuptools-49.6.0
  Successfully installed cython-0.28.6 setuptools-50.3.0
  WARNING: You are using pip version 20.2.2; however, version 20.2.3 is
  available.
  You should consider upgrading via the
  '/home/tanabe/LogDevice/_build/staging/usr/local/bin/python3 -m pip
  install --upgrade pip' command.

 -- Found Cython Version 0.28.6                                                                                                                                                                                                               CMake Error at                                                                                                                                                                                                                               /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:137                                                                                                                                                                        (message):                                                                                                                                                                                                                                     Could NOT find Cython: Found unsuitable version "0.28.6", but required                                                                                                                                                                       is                                                                                                                                                                                                                                           at least "0.29" (found                                                                                                                                                                                                                           /home/tanabe/LogDevice/_build/staging/usr/local/bin/cython) 